### PR TITLE
Make classRegistry protected

### DIFF
--- a/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
+++ b/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
@@ -495,7 +495,7 @@ class FunctionGeneratorTest {
 		val result = function.contributeFields(javaNames)
 		concatenator.append(result)
 		
-		val expected = '''private final ClassToInstanceMap<RosettaFunction> classRegistry;'''
+		val expected = '''protected final ClassToInstanceMap<RosettaFunction> classRegistry;'''
 		
 		assertEquals(expected.trim, concatenator.toString.trim)
 		assertThat(concatenator.imports, hasItems(endsWith('.ClassToInstanceMap'), endsWith('.RosettaFunction')))

--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
@@ -186,7 +186,7 @@ class FunctionGenerator implements RosettaInternalGenerator {
 	def StringConcatenationClient contributeFields(extension RosettaFunction function, extension JavaQualifiedTypeProvider names) {
 		'''
 		
-		private final «ClassToInstanceMap»<«com.rosetta.model.lib.functions.RosettaFunction»> classRegistry;
+		protected final «ClassToInstanceMap»<«com.rosetta.model.lib.functions.RosettaFunction»> classRegistry;
 		'''	
 	}
 	


### PR DESCRIPTION
So that the class registry can be used in implementations of the abstract class.