### PR TITLE
Code gen npe fix

### DIFF
--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/RosettaGenerator.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/RosettaGenerator.xtend
@@ -80,7 +80,10 @@ class RosettaGenerator extends AbstractGenerator {
 			lock.getWriteLock(true);
 			if (!ignoredFiles.contains(resource.URI.segments.last)) {
 				// all models
-				val models = resource.resourceSet.resources.flatMap[contents].filter(RosettaModel).toSet
+				val models = if (resource.resourceSet?.resources === null) {
+					LOGGER.warn("No resource set found for " + resource.URI.toString)
+					newHashSet
+				} else resource.resourceSet.resources.flatMap[contents]?.filter(RosettaModel)?.toSet
 
 				// generate for each model object
 				resource.contents.filter(RosettaModel).forEach [

--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/RosettaGenerator.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/RosettaGenerator.xtend
@@ -83,7 +83,7 @@ class RosettaGenerator extends AbstractGenerator {
 				val models = if (resource.resourceSet?.resources === null) {
 					LOGGER.warn("No resource set found for " + resource.URI.toString)
 					newHashSet
-				} else resource.resourceSet.resources.flatMap[contents]?.filter(RosettaModel)?.toSet
+				} else resource.resourceSet.resources.flatMap[contents].filter(RosettaModel).toSet
 
 				// generate for each model object
 				resource.contents.filter(RosettaModel).forEach [


### PR DESCRIPTION
We see a NPE sometimes during edits in Rosetta Core.

The Null pointer is in generated xtend code:
```
final Set<RosettaModel> models = IterableExtensions.<RosettaModel>toSet(Iterables.<RosettaModel>filter(IterableExtensions.<Resource, EObject>flatMap(resource.getResourceSet().getResources(), _function), RosettaModel.class));
```

I suspect that we do not get a null resource set which causes the issue.


Full stack trace:

```
WARN  [2020-05-04 10:22:08,243] [RequestManager-Queue-0] [] com.regnosys.rosetta.generator.RosettaGenerator: Unexpected calling standard generate for rosetta -null - see debug logging for more
INFO  [2020-05-04 10:22:08,243] [RequestManager-Queue-0] [] com.regnosys.rosetta.generator.RosettaGenerator: Unexpected calling standard generate for rosetta
! java.lang.NullPointerException: null
! at com.regnosys.rosetta.generator.RosettaGenerator.doGenerate(RosettaGenerator.java:145)
! at com.regnosys.rosetta.editor.generator.XTextGenerateHandler.lambda$doGenerate$1(XTextGenerateHandler.java:74)
! at java.base/java.util.concurrent.ConcurrentHashMap$ForEachValueTask.compute(Unknown Source)
! at java.base/java.util.concurrent.CountedCompleter.exec(Unknown Source)
! at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
! at java.base/java.util.concurrent.ForkJoinTask.doInvoke(Unknown Source)
! at java.base/java.util.concurrent.ForkJoinTask.invoke(Unknown Source)
! at java.base/java.util.concurrent.ConcurrentHashMap.forEachValue(Unknown Source)
! at com.regnosys.rosetta.editor.generator.XTextGenerateHandler.doGenerate(XTextGenerateHandler.java:74)
! at org.eclipse.xtext.generator.GeneratorDelegate.doGenerate(GeneratorDelegate.java:43)
! at org.eclipse.xtext.generator.GeneratorDelegate.generate(GeneratorDelegate.java:34)
! at org.eclipse.xtext.build.IncrementalBuilder$InternalStatefulIncrementalBuilder.generate(IncrementalBuilder.java:360)
! at org.eclipse.xtext.build.IncrementalBuilder$InternalStatefulIncrementalBuilder.lambda$launch$6(IncrementalBuilder.java:294)
! at org.eclipse.xtext.build.ClusteringStorageAwareResourceLoader.lambda$executeClustered$1(ClusteringStorageAwareResourceLoader.java:75)
! at org.eclipse.xtext.xbase.lib.internal.FunctionDelegate.apply(FunctionDelegate.java:42)
! at com.google.common.collect.Lists$TransformingRandomAccessList$1.transform(Lists.java:616)
! at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
! at java.base/java.util.AbstractCollection.toArray(Unknown Source)
! at java.base/java.util.ArrayList.addAll(Unknown Source)
! at com.google.common.collect.Iterables.addAll(Iterables.java:318)
! at org.eclipse.xtext.build.ClusteringStorageAwareResourceLoader.executeClustered(ClusteringStorageAwareResourceLoader.java:78)
! at org.eclipse.xtext.build.BuildContext.executeClustered(BuildContext.java:55)
! at org.eclipse.xtext.build.IncrementalBuilder$InternalStatefulIncrementalBuilder.launch(IncrementalBuilder.java:299)
! at org.eclipse.xtext.build.IncrementalBuilder.build(IncrementalBuilder.java:419)
! at org.eclipse.xtext.build.IncrementalBuilder.build(IncrementalBuilder.java:404)
! at org.eclipse.xtext.ide.server.ProjectManager.doBuild(ProjectManager.java:115)
! at org.eclipse.xtext.ide.server.BuildManager.internalBuild(BuildManager.java:181)
! at org.eclipse.xtext.ide.server.BuildManager.lambda$submit$0(BuildManager.java:129)
! at org.eclipse.xtext.ide.server.WorkspaceManager.lambda$didChangeFiles$2(WorkspaceManager.java:174)
! at org.eclipse.xtext.ide.server.LanguageServerImpl.lambda$didChange$17(LanguageServerImpl.java:390)
! at org.eclipse.xtext.ide.server.concurrent.WriteRequest.run(WriteRequest.java:40)
! at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
! at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
! at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
! at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
! at java.base/java.lang.Thread.run(Unknown Source)

```