### PR TITLE
Avoid NPE

### DIFF
--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/util/RosettaAttributeExtensions.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/util/RosettaAttributeExtensions.xtend
@@ -226,7 +226,7 @@ class RosettaAttributeExtensions {
 		val metas = <ExpandedAttribute>newArrayList
 		attr.annotations.forEach [ annoRef, i |
 			val annoAttr = annoRef?.attribute
-			if(annoAttr!==null) {
+			if(annoAttr !== null && annoAttr.type !== null) {
 				metas.add(new ExpandedAttribute(
 					annoAttr.name,
 					annoRef.annotation.name,


### PR DESCRIPTION
When editing the model in Rosetta Core, we sometimes get an NPE when generating code.

Full stack trace:

```
! java.lang.NullPointerException: null
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.toExpandedType(RosettaAttributeExtensions.java:405)
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.lambda$22(RosettaAttributeExtensions.java:370)
! at org.eclipse.xtext.xbase.lib.IteratorExtensions.forEach(IteratorExtensions.java:445)
! at org.eclipse.xtext.xbase.lib.IterableExtensions.forEach(IterableExtensions.java:413)
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.toExpandedAttribute(RosettaAttributeExtensions.java:385)
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.lambda$1(RosettaAttributeExtensions.java:87)
! at org.eclipse.xtext.xbase.lib.internal.FunctionDelegate.apply(FunctionDelegate.java:42)
! at com.google.common.collect.Lists$TransformingRandomAccessList$1.transform(Lists.java:616)
! at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
! at com.google.common.collect.Iterators$ConcatenatedIterator.next(Iterators.java:1363)
! at com.google.common.collect.Iterators.addAll(Iterators.java:358)
! at com.google.common.collect.Lists.newArrayList(Lists.java:147)
! at com.google.common.collect.Lists.newArrayList(Lists.java:133)
! at org.eclipse.xtext.xbase.lib.IterableExtensions.sortBy(IterableExtensions.java:792)
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.getExpandedAttributes(RosettaAttributeExtensions.java:97)
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions._getExpandedAttributes(RosettaAttributeExtensions.java:105)
! at com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.getExpandedAttributes(RosettaAttributeExtensions.java:601)
! at com.regnosys.rosetta.translate.synonymmap.SynonymMapBuilder.getAllAttributes(SynonymMapBuilder.java:433)
```

The java code where the NPE is:

```
public static ExpandedType toExpandedType(final RosettaType type) {
NPE >>>   RosettaModel _model = type.getModel();
  String _name = type.getName();
  return new ExpandedType(_model, _name, ((type instanceof Data) || (type instanceof RosettaClass)), (type instanceof RosettaEnumeration), (type instanceof RosettaMetaType));
}
```

Looks like there is a scenario where we have a meta annotation and generate an `ExpandedAttribute` from it that does not have a type in the model yet. Possibly this happens during an edit.


