### PR TITLE
Added ability to extend a Rosetta type with the same attribute so tha…

### DIFF
--- a/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/generator/java/object/ModelObjectGeneratorTest.xtend
+++ b/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/generator/java/object/ModelObjectGeneratorTest.xtend
@@ -389,7 +389,7 @@ class ModelObjectGeneratorTest {
 			type Bar extends Foo:
 				a string (0..1)
 		'''.generateCode
-		code.writeClasses('shouldExtendATypeWithSameAttribute')
+		//code.writeClasses('shouldExtendATypeWithSameAttribute')
 		val classes = code.compileToClasses
 	}
 	

--- a/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/generator/java/object/ModelObjectGeneratorTest.xtend
+++ b/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/generator/java/object/ModelObjectGeneratorTest.xtend
@@ -380,6 +380,20 @@ class ModelObjectGeneratorTest {
 	}
 
 	@Test
+	def shouldExtendATypeWithSameAttribute() {
+		val code = '''
+			type Foo:
+				a string (0..1)
+				b string (0..1)
+			
+			type Bar extends Foo:
+				a string (0..1)
+		'''.generateCode
+		code.writeClasses('shouldExtendATypeWithSameAttribute')
+		val classes = code.compileToClasses
+	}
+	
+	@Test
 	def shouldGenerateRosettaQualifiedAnnotationForEventType() {
 		val code = '''
 			isEvent root Foo;

--- a/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/validation/RosettaValidatorTest.xtend
+++ b/com.regnosys.rosetta.tests/src/com/regnosys/rosetta/validation/RosettaValidatorTest.xtend
@@ -276,9 +276,46 @@ class RosettaValidatorTest implements RosettaIssueCodes {
 			type Bar extends Foo:
 				i int (1..1)
 		'''.parseRosetta
-		model.assertError(ATTRIBUTE, DUPLICATE_ATTRIBUTE, 'Duplicate attribute')
+		model.assertNoErrors
 	}
 	
+	@Test
+	def void testDuplicateAttributeNotAllowedWithDiffCard1() {
+		val model = '''
+			type Foo:
+				i int (1..1)
+			
+			type Bar extends Foo:
+				i int (0..1)
+		'''.parseRosetta
+		model.assertError(ATTRIBUTE, CARDINALITY_ERROR, "Overriding attribute 'i' with cardinality (0..1) must match the cardinality of the attribute it overrides (1..1)")
+	}
+	
+	@Test
+	def void testDuplicateAttributeNotAllowedWithDiffCard2() {
+		val model = '''
+			type Foo:
+				i int (1..1)
+			
+			type Bar extends Foo:
+				i int (1..*)
+		'''.parseRosetta
+		model.assertError(ATTRIBUTE, CARDINALITY_ERROR, "Overriding attribute 'i' with cardinality (1..*) must match the cardinality of the attribute it overrides (1..1)")
+	}
+	
+	@Test
+	def void testDuplicateAttributeNotAllowedWithDiffType() {
+		val model = '''
+			type Foo:
+				i int (1..1)
+			
+			type Bar extends Foo:
+				i string (1..1)
+		'''.parseRosetta
+		model.assertError(ATTRIBUTE, DUPLICATE_ATTRIBUTE, "Overriding attribute 'i' with type (string) must match the type of the attribute it overrides (int)")
+	}
+	
+
 	@Test
 	def void testDuplicateAttributeWithOverride() {
 		val model = '''

--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/RosettaExtensions.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/RosettaExtensions.xtend
@@ -19,6 +19,8 @@ import java.util.Set
 import org.eclipse.emf.common.util.URI
 
 import static extension com.regnosys.rosetta.generator.util.RosettaAttributeExtensions.*
+import com.regnosys.rosetta.rosetta.simple.Attribute
+import java.util.List
 
 class RosettaExtensions {
 	
@@ -39,6 +41,21 @@ class RosettaExtensions {
 	
 	def Set<RosettaEnumeration> getAllSuperEnumerations(RosettaEnumeration e) {
 		doGetSuperEnumerations(e, newLinkedHashSet)
+	}
+	
+	 def List<Attribute>allNonOverridesAttributes(Data data) {
+		val atts = newArrayList;
+		atts.addAll(data.attributes)
+		if (data.hasSuperType) {
+			atts.addAll(data.superType.allNonOverridesAttributes
+				.filter[superAttr| !atts.exists[extendedAttr|					
+					superAttr.name == extendedAttr.name && 
+					superAttr.type == extendedAttr.type && 
+					superAttr.card.inf == extendedAttr.card.inf &&
+					superAttr.card.sup == extendedAttr.card.sup
+				]].toList)
+		}
+		return atts
 	}
 	
 	private def Set<RosettaEnumeration> doGetSuperEnumerations(RosettaEnumeration e, Set<RosettaEnumeration> seenEnums) {
@@ -211,7 +228,7 @@ class RosettaExtensions {
 	 * Recursively collects all reporting rules for all attributes
 	 */
 	def void collectReportingRules(Data dataType, (RosettaBlueprint) => void visitor, Set<Data> collectedTypes) {
-		dataType.allAttributes.forEach[attr|
+		dataType.allNonOverridesAttributes.forEach[attr|
 			val attrType = attr.type
 			val attrEx = attr.toExpandedAttribute
 			if (attrEx.builtInType || attrEx.enum) {

--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/util/RosettaAttributeExtensions.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/generator/util/RosettaAttributeExtensions.xtend
@@ -55,7 +55,15 @@ class RosettaAttributeExtensions {
 	
 	static def List<ExpandedAttribute> expandedAttributesPlus(Data data) {
 		val atts = data.expandedAttributes;
-		if (data.hasSuperType) atts.addAll(data.superType.expandedAttributesPlus)
+		if (data.hasSuperType) {
+			atts.addAll(data.superType.expandedAttributesPlus
+				.filter[superAttr| !atts.exists[extendedAttr|					
+					superAttr.name == extendedAttr.name && 
+					superAttr.type == extendedAttr.type && 
+					superAttr.inf == extendedAttr.inf && 
+					superAttr.sup == extendedAttr.sup
+				]].toList)
+		}
 		return atts
 	}
 	

--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/validation/RosettaValidator.xtend
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/validation/RosettaValidator.xtend
@@ -267,9 +267,13 @@ class RosettaValidator extends AbstractRosettaValidator implements RosettaIssueC
 	protected def void checkNonOverridingAttributeNamesAreUnique( Iterable<Attribute> attrFromClazzes, Iterable<Attribute> attrFromSuperClasses, String name) {
 		val messageExtension = if (attrFromSuperClasses.empty) '' else ' (extends ' + attrFromSuperClasses.attributeTypeNames + ')'
 		
-		attrFromClazzes.filter[!override].forEach [
-			error('''Duplicate attribute '«name»'«messageExtension»''', it, ROSETTA_NAMED__NAME,
-				DUPLICATE_ATTRIBUTE)
+		attrFromClazzes.filter[!override].forEach [ childAttr |
+			attrFromSuperClasses.forEach [ parentAttr |
+				if (childAttr.type !== parentAttr.type && childAttr.card !== parentAttr.card) {
+					error('''Overriding attribute '«name»' must have a type that overrides its parent attribute type of «parentAttr.type.name»''',
+						childAttr, ROSETTA_NAMED__NAME, DUPLICATE_ATTRIBUTE)
+				}
+			]
 		]
 	}
 	


### PR DESCRIPTION
This change allows an extended type define an attribute that is present in a super class iff and only if the name, type and cardinality are the same. The reason for the change is so that in the regulatory syntax, an reporting rule annotation can be overridden to avoid duplicating the type. 
