### PR TITLE
Added minimal support for XSemantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build.acceleo
 **/xtend-gen/
 **/emf-gen/
 **/src/generated/
+**/xsemantics-gen/
 
 .antlr-generator-3.2.0-patch.jar
 com.regnosys.rosetta.web/

--- a/com.regnosys.rosetta.target/com.regnosys.rosetta.target.target
+++ b/com.regnosys.rosetta.target/com.regnosys.rosetta.target.target
@@ -38,5 +38,17 @@
 			<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
 			<unit id="org.slf4j.binding.simple.source" version="1.7.30.v20200204-2150"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/xsemantics/milestones/"/>
+			<unit id="org.eclipse.xsemantics.doc.feature.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.examples.feature.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.feature.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.feature.source.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.implemented.examples.feature.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.runtime.feature.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.runtime.feature.source.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.sdk.feature.group" version="1.20.0.v20210401-0731"/>
+			<unit id="org.eclipse.xsemantics.sdk.source.feature.group" version="1.20.0.v20210401-0731"/>
+		</location>
 	</locations>
 </target>

--- a/com.regnosys.rosetta.tests/.classpath
+++ b/com.regnosys.rosetta.tests/.classpath
@@ -13,24 +13,14 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src-gen/">
+	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="xtend-gen/">
+	<classpathentry kind="src" path="xtend-gen">
 		<attributes>
 			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src-test/java/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="test-resources/">
-		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/com.regnosys.rosetta/.classpath
+++ b/com.regnosys.rosetta/.classpath
@@ -7,6 +7,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="xsemantics-gen"/>
 	<classpathentry kind="src" path="src-gen/">
 		<attributes>
 			<attribute name="ignore_optional_problems" value="true"/>

--- a/com.regnosys.rosetta/META-INF/MANIFEST.MF
+++ b/com.regnosys.rosetta/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: com.google.guava,
  org.eclipse.xtext.util,
  org.eclipse.xtext.xbase,
  org.eclipse.xtext.xbase.lib;bundle-version="2.25.0",
- org.eclipse.xtext
+ org.eclipse.xtext,
+ org.eclipse.xsemantics.runtime;bundle-version="1.20.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.apache.log4j,
  com.rosetta.util

--- a/com.regnosys.rosetta/src/com/regnosys/rosetta/types/Rosetta.xsemantics
+++ b/com.regnosys.rosetta/src/com/regnosys/rosetta/types/Rosetta.xsemantics
@@ -1,0 +1,3 @@
+system com.regnosys.rosetta.typing.RosettaTyping
+
+validatorExtends com.regnosys.rosetta.validation.RosettaValidator


### PR DESCRIPTION
This only adds some dependencies and configures XSemantics, but does not affect the Rosetta DSL in any way.

All developers of this project should follow 'step 1' from the [wiki](https://github.com/REGnosys/rosetta-dsl/wiki/XSemantics-setup) on how to install support for XSemantics into Eclipse and reload their target platform.