### PR TITLE
Unknown OSGi execution environment: 'JavaSE-18'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.release>8</maven.compiler.release>
 		<!-- Tycho settings -->
-		<tycho-version>2.5.0</tycho-version>
+		<tycho-version>2.7.5</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin IMPORTANT THESE PROPERTIES ARE SOMETIMES OVERRIDEN BUT NEED TO BE BLANK OTHERWISE -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>


### PR DESCRIPTION
Tried to `mvn install` from a fresh project checkout (using both Java 14 and Java 18) and got the following error

```
[ERROR] Internal error: org.eclipse.tycho.core.ee.UnknownEnvironmentException: Unknown OSGi execution environment: 'JavaSE-18'
```

The issue was solved by updating the Tycho plugins to its latest version, `2.7.5`.

Hope this helps!