### PR TITLE
get rid of no slf4j implementation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 		<!-- test -->
 		<junit.version>5.8.2</junit.version>
 		<mockito-core.version>5.1.1</mockito-core.version>
+		<logback.version>1.4.7</logback.version>
 
 		<!-- Plugin and plugin dependency management -->
 		<org.eclipse.emf.ecore.xcore.version>1.23.0</org.eclipse.emf.ecore.xcore.version>
@@ -214,6 +215,18 @@
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>${mockito-core.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>${logback.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-core</artifactId>
+				<version>${logback.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/rosetta-ide/pom.xml
+++ b/rosetta-ide/pom.xml
@@ -46,6 +46,16 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rosetta-testing/pom.xml
+++ b/rosetta-testing/pom.xml
@@ -39,6 +39,16 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rosetta-tools/pom.xml
+++ b/rosetta-tools/pom.xml
@@ -78,5 +78,15 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Get rid of no slf4j implementation warnings

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
