### PR TITLE
STORY-2420: A User can view human-readable DSL syntax without brackets

### DIFF
--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/RosettaIdeModule.xtend
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/RosettaIdeModule.xtend
@@ -20,6 +20,10 @@ import com.regnosys.rosetta.ide.semantictokens.RosettaSemanticTokenTypesProvider
 import com.regnosys.rosetta.ide.textmate.RosettaTextMateGrammarUtil
 import org.eclipse.xtext.ide.server.formatting.FormattingService
 import com.regnosys.rosetta.ide.formatting.RosettaFormattingService
+import org.eclipse.xtext.ide.editor.quickfix.IQuickFixProvider
+import com.regnosys.rosetta.ide.quickfix.RosettaQuickFixProvider
+import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2
+import com.regnosys.rosetta.ide.quickfix.RosettaQuickFixCodeActionService
 
 /**
  * Use this class to register ide components.
@@ -64,5 +68,13 @@ class RosettaIdeModule extends AbstractRosettaIdeModule {
 
 	def Class<? extends FormattingService> bindFormattingService() {
 		RosettaFormattingService
+	}
+	
+	def Class<? extends IQuickFixProvider> bindIQuickFixProvider() {
+		RosettaQuickFixProvider
+	}
+	
+	def Class<? extends ICodeActionService2> bindICodeActionService2() {
+		RosettaQuickFixCodeActionService
 	}
 }

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/quickfix/RosettaQuickFixCodeActionService.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/quickfix/RosettaQuickFixCodeActionService.java
@@ -1,0 +1,82 @@
+package com.regnosys.rosetta.ide.quickfix;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolution;
+import org.eclipse.xtext.ide.editor.quickfix.IQuickFixProvider;
+import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2;
+
+/*
+ * TODO: contribute to Xtext.
+ * This is a patch of org.eclipse.xtext.ide.server.codeActions.QuickFixCodeActionService.
+ */
+public class RosettaQuickFixCodeActionService implements ICodeActionService2 {
+
+	@Inject
+	private IQuickFixProvider quickfixes;
+
+	@Override
+	public List<Either<Command, CodeAction>> getCodeActions(Options options) {
+		boolean handleQuickfixes = options.getCodeActionParams().getContext().getOnly() == null
+				|| options.getCodeActionParams().getContext().getOnly().isEmpty()
+				|| options.getCodeActionParams().getContext().getOnly().contains(CodeActionKind.QuickFix);
+
+		if (!handleQuickfixes) {
+			return Collections.emptyList();
+		}
+
+		List<Either<Command, CodeAction>> result = new ArrayList<>();
+		for (Diagnostic diagnostic : options.getCodeActionParams().getContext().getDiagnostics()) {
+			Options diagnosticOptions = createOptionsForSingleDiagnostic(options, diagnostic);
+			List<DiagnosticResolution> resolutions = quickfixes.getResolutions(diagnosticOptions, diagnostic).stream()
+					.sorted(Comparator.nullsLast(Comparator.comparing(DiagnosticResolution::getLabel)))
+					.collect(Collectors.toList());
+			for (DiagnosticResolution resolution : resolutions) {
+				result.add(Either.forRight(createFix(resolution, diagnostic)));
+			}
+		}
+		return result;
+	}
+
+	private CodeAction createFix(DiagnosticResolution resolution, Diagnostic diagnostic) {
+		CodeAction codeAction = new CodeAction();
+		codeAction.setDiagnostics(Collections.singletonList(diagnostic));
+		codeAction.setTitle(resolution.getLabel());
+		codeAction.setEdit(resolution.apply());
+		codeAction.setKind(CodeActionKind.QuickFix);
+
+		return codeAction;
+	}
+	
+	private Options createOptionsForSingleDiagnostic(Options base, Diagnostic diagnostic) {
+		Options options = new Options();
+		options.setCancelIndicator(base.getCancelIndicator());
+		options.setDocument(base.getDocument());
+		options.setLanguageServerAccess(base.getLanguageServerAccess());
+		options.setResource(base.getResource());
+		
+		CodeActionParams baseParams = base.getCodeActionParams();
+		CodeActionContext baseContext = baseParams.getContext();
+		CodeActionContext context = new CodeActionContext(List.of(diagnostic), baseContext.getOnly());
+		context.setTriggerKind(baseContext.getTriggerKind());
+		CodeActionParams params = new CodeActionParams(baseParams.getTextDocument(), diagnostic.getRange(), context);
+		
+		options.setCodeActionParams(params);
+		
+		return options;
+	}
+
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/quickfix/RosettaQuickFixProvider.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/quickfix/RosettaQuickFixProvider.java
@@ -1,0 +1,56 @@
+package com.regnosys.rosetta.ide.quickfix;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.xtext.ide.editor.quickfix.AbstractDeclarativeIdeQuickfixProvider;
+import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolutionAcceptor;
+import org.eclipse.xtext.ide.editor.quickfix.QuickFix;
+import org.eclipse.xtext.ide.server.Document;
+
+import com.regnosys.rosetta.ide.util.RangeUtils;
+import com.regnosys.rosetta.validation.RosettaIssueCodes;
+import com.regnosys.rosetta.rosetta.expression.RosettaUnaryOperation;
+import static com.regnosys.rosetta.rosetta.expression.ExpressionPackage.Literals.*;
+
+public class RosettaQuickFixProvider extends AbstractDeclarativeIdeQuickfixProvider {
+	@Inject
+	private RangeUtils rangeUtils;
+	
+	@QuickFix(RosettaIssueCodes.REDUNDANT_SQUARE_BRACKETS)
+	public void fixRedundantSquareBrackets(DiagnosticResolutionAcceptor acceptor) {
+		acceptor.accept("Remove square brackets.", (Diagnostic diagnostic, EObject object, Document document) -> {
+			Range range = rangeUtils.getRange(object);
+			String original = document.getSubstring(range);
+			String edited = original.substring(1, original.length() - 1).replaceAll("^ +|\\s+$", "");
+			return createTextEdit(diagnostic, edited);
+		});
+	}
+	
+	@QuickFix(RosettaIssueCodes.MANDATORY_SQUARE_BRACKETS)
+	public void fixMandatorySquareBrackets(DiagnosticResolutionAcceptor acceptor) {
+		acceptor.accept("Add square brackets.", (Diagnostic diagnostic, EObject object, Document document) -> {
+			Range range = rangeUtils.getRange(object);
+			String original = document.getSubstring(range);
+			String edited = "[ " + original + " ]";
+			return createTextEdit(diagnostic, edited);
+		});
+	}
+	
+	@QuickFix(RosettaIssueCodes.MANDATORY_THEN)
+	public void fixMandatoryThen(DiagnosticResolutionAcceptor acceptor) {
+		acceptor.accept("Add `then`.", (Diagnostic diagnostic, EObject object, Document document) -> {
+			RosettaUnaryOperation op = (RosettaUnaryOperation)object;
+			Range range = rangeUtils.getRange(op, ROSETTA_OPERATION__OPERATOR);
+			String original = document.getSubstring(range);
+			String edited = "then " + original;
+			TextEdit edit = new TextEdit(range, edited);
+			return List.of(edit);
+		});
+	}
+}

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/inlayhints/tests/InlayHintTest.xtend
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/inlayhints/tests/InlayHintTest.xtend
@@ -22,8 +22,8 @@ class InlayHintTest extends AbstractRosettaLanguageServerTest {
 			func Bar:
 				output:
 					result int (0..*)
-				set result:
-					[0, 1, 2] extract [ Foo ]
+				add result:
+					[0, 1, 2] extract i [ Foo(i) ]
 			'''
 			it.model = model
 			it.assertNumberOfInlayHints = 1

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/quickfix/QuickFixTest.xtend
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/quickfix/QuickFixTest.xtend
@@ -1,0 +1,58 @@
+package com.regnosys.rosetta.ide.quickfix
+
+import org.junit.jupiter.api.Test
+import com.regnosys.rosetta.ide.tests.AbstractRosettaLanguageServerTest
+import static org.junit.jupiter.api.Assertions.*
+import org.eclipse.lsp4j.Position
+import javax.inject.Inject
+import com.regnosys.rosetta.ide.util.RangeUtils
+
+class QuickFixTest extends AbstractRosettaLanguageServerTest {
+	@Inject RangeUtils ru
+	
+	@Test
+	def testQuickFixRedundantSquareBrackets() {
+		val model = '''
+		namespace foo.bar
+		
+		type Foo:
+			a int (1..1)
+		
+		func Bar:
+			inputs: foo Foo (1..1)
+			output: result int (1..1)
+			
+			set result:
+				foo
+					extract [ a ]
+					extract [ 42 ]
+		'''
+		testCodeAction[
+			it.model = model
+			assertCodeActions = [
+				assertEquals(2, size)
+				
+				val sorted = it.sortWith[a,b| ru.comparePositions(a.getRight.diagnostics.head.range.start, b.getRight.diagnostics.head.range.start)]
+				
+				sorted.get(0).getRight => [
+					assertEquals("Add `then`.", title)
+					edit.changes.values.head.head => [
+						assertEquals("then extract", newText)
+						assertEquals(new Position(12, 3), range.start)
+						assertEquals(new Position(12, 10), range.end)
+					]
+				]
+				
+				sorted.get(1).getRight => [
+					assertEquals("Remove square brackets.", title)
+					edit.changes.values.head.head => [
+						assertEquals("42", newText)
+						assertEquals(new Position(12, 11), range.start)
+						assertEquals(new Position(12, 17), range.end)
+					]
+				]
+			]
+		]
+	}
+	
+}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/FormattingUtil.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/FormattingUtil.java
@@ -8,7 +8,6 @@ import org.eclipse.xtext.formatting2.IFormattableSubDocument;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
 import org.eclipse.xtext.formatting2.regionaccess.IEObjectRegion;
 import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion;
-import org.eclipse.xtext.formatting2.regionaccess.ISequentialRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions;
 import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 import org.eclipse.xtext.preferences.TypedPreferenceKey;
@@ -27,23 +26,24 @@ public class FormattingUtil {
 	}
 	public void formatInlineOrMultiline(IFormattableDocument document, EObject object, FormattingMode mode, int maxLineWidth, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
 		IEObjectRegion objRegion = getTextRegionExt(document).regionForEObject(object);
-		formatInlineOrMultiline(document, objRegion, mode, maxLineWidth, inlineFormatter, multilineFormatter);
+		// I need to include the next hidden region in the conditional formatting as well,
+		 // because that's where I might decrease indentation in case of a (long) multi-line operation.
+		ITextSegment formattableRegion = objRegion.merge(objRegion.getNextHiddenRegion());
+		formatInlineOrMultiline(document, objRegion, formattableRegion, mode, maxLineWidth, inlineFormatter, multilineFormatter);
 	}
-	public void formatInlineOrMultiline(IFormattableDocument document, ISequentialRegion objRegion, FormattingMode mode, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
+	public void formatInlineOrMultiline(IFormattableDocument document, ITextSegment astRegion, ITextSegment formattableRegion, FormattingMode mode, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
 		int maxLineWidth = getPreference(document, RosettaFormatterPreferenceKeys.maxLineWidth);
-		formatInlineOrMultiline(document, objRegion, mode, maxLineWidth, inlineFormatter, multilineFormatter);
+		formatInlineOrMultiline(document, astRegion, formattableRegion, mode, maxLineWidth, inlineFormatter, multilineFormatter);
 	}
-	public void formatInlineOrMultiline(IFormattableDocument document, ISequentialRegion objRegion, FormattingMode mode, int maxLineWidth, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
+	public void formatInlineOrMultiline(IFormattableDocument document, ITextSegment astRegion, ITextSegment formattableRegion, FormattingMode mode, int maxLineWidth, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
 		if (mode.equals(FormattingMode.NORMAL)) {
-			 // I need to include the next hidden region in the conditional formatting as well,
-			 // because that's where I might decrease indentation in case of a (long) multi-line operation.
-			ITextSegment region = objRegion.merge(objRegion.getNextHiddenRegion());
-			document.formatConditionally(region.getOffset(), region.getLength(),
+			document.formatConditionally(formattableRegion.getOffset(), formattableRegion.getLength(),
 					(doc) -> { // case: short region
 						IFormattableSubDocument singleLineDoc =
 								requireTrimmedFitsInLine(
 										doc,
-										objRegion,
+										astRegion,
+										formattableRegion,
 										maxLineWidth
 								);
 						inlineFormatter.accept(singleLineDoc);
@@ -59,8 +59,8 @@ public class FormattingUtil {
 		}
 	}
 	
-	public IFormattableSubDocument requireTrimmedFitsInLine(IFormattableDocument document, ISequentialRegion segment, int maxLineWidth) {
-		TrimmedMaxLineWidthDocument subdoc = new TrimmedMaxLineWidthDocument(segment, document, maxLineWidth);
+	public IFormattableSubDocument requireTrimmedFitsInLine(IFormattableDocument document, ITextSegment astRegion, ITextSegment formattableRegion, int maxLineWidth) {
+		TrimmedMaxLineWidthDocument subdoc = new TrimmedMaxLineWidthDocument(astRegion, formattableRegion, document, maxLineWidth);
 		document.addReplacer(subdoc);
 		return subdoc;
 	}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/FormattingUtil.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/FormattingUtil.java
@@ -6,9 +6,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.IFormattableSubDocument;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
-import org.eclipse.xtext.formatting2.regionaccess.IAstRegion;
 import org.eclipse.xtext.formatting2.regionaccess.IEObjectRegion;
 import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion;
+import org.eclipse.xtext.formatting2.regionaccess.ISequentialRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions;
 import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 import org.eclipse.xtext.preferences.TypedPreferenceKey;
@@ -26,8 +26,15 @@ public class FormattingUtil {
 		formatInlineOrMultiline(document, object, mode, maxLineWidth, inlineFormatter, multilineFormatter);
 	}
 	public void formatInlineOrMultiline(IFormattableDocument document, EObject object, FormattingMode mode, int maxLineWidth, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
+		IEObjectRegion objRegion = getTextRegionExt(document).regionForEObject(object);
+		formatInlineOrMultiline(document, objRegion, mode, maxLineWidth, inlineFormatter, multilineFormatter);
+	}
+	public void formatInlineOrMultiline(IFormattableDocument document, ISequentialRegion objRegion, FormattingMode mode, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
+		int maxLineWidth = getPreference(document, RosettaFormatterPreferenceKeys.maxLineWidth);
+		formatInlineOrMultiline(document, objRegion, mode, maxLineWidth, inlineFormatter, multilineFormatter);
+	}
+	public void formatInlineOrMultiline(IFormattableDocument document, ISequentialRegion objRegion, FormattingMode mode, int maxLineWidth, Consumer<IFormattableDocument> inlineFormatter, Consumer<IFormattableDocument> multilineFormatter) {
 		if (mode.equals(FormattingMode.NORMAL)) {
-			IEObjectRegion objRegion = getTextRegionExt(document).regionForEObject(object);
 			 // I need to include the next hidden region in the conditional formatting as well,
 			 // because that's where I might decrease indentation in case of a (long) multi-line operation.
 			ITextSegment region = objRegion.merge(objRegion.getNextHiddenRegion());
@@ -52,7 +59,7 @@ public class FormattingUtil {
 		}
 	}
 	
-	public IFormattableSubDocument requireTrimmedFitsInLine(IFormattableDocument document, IAstRegion segment, int maxLineWidth) {
+	public IFormattableSubDocument requireTrimmedFitsInLine(IFormattableDocument document, ISequentialRegion segment, int maxLineWidth) {
 		TrimmedMaxLineWidthDocument subdoc = new TrimmedMaxLineWidthDocument(segment, document, maxLineWidth);
 		document.addReplacer(subdoc);
 		return subdoc;

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormatter.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormatter.xtend
@@ -348,9 +348,12 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 				]
 			)
 		} else { // case inline function without brackets
-			formatInlineOrMultiline(document, f.regionForEObject, mode,
+			val astRegion = f.regionForEObject
+			val formattableRegion = astRegion.merge(astRegion.previousHiddenRegion).merge(astRegion.nextHiddenRegion)
+			formatInlineOrMultiline(document, astRegion, formattableRegion, mode,
 				[extension doc | // case: short inline function
 					f.body
+						.prepend[oneSpace]
 						.formatExpression(document, mode)
 					if (f.eContainer.eContainer instanceof RosettaOperation) {
 						// Always put next operations on a new line.
@@ -358,8 +361,11 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 					}
 				],
 				[extension doc | // case: long inline function
-					f.body
-						.formatExpression(document, mode)
+					surround(
+						f.body
+							.prepend[newLine],
+						[indent]
+					).formatExpression(document, mode)
 				]
 			)
 		}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormatter.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormatter.xtend
@@ -35,6 +35,7 @@ import com.regnosys.rosetta.rosetta.expression.ArithmeticOperation
 import com.regnosys.rosetta.rosetta.expression.ChoiceOperation
 import com.regnosys.rosetta.rosetta.expression.ComparisonOperation
 import com.regnosys.rosetta.rosetta.expression.RosettaOperation
+import com.regnosys.rosetta.rosetta.expression.ThenOperation
 
 class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 	
@@ -305,6 +306,7 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 			mode,
 			[extension doc |
 				if (expr.function !== null) {
+					expr.regionFor.keyword("extract").append[oneSpace]
 					expr.function.formatInlineFunction(doc, mode.stopChain)
 				}
 			]
@@ -350,11 +352,11 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 		} else { // case inline function without brackets
 			val astRegion = f.regionForEObject
 			val formattableRegion = astRegion.merge(astRegion.previousHiddenRegion).merge(astRegion.nextHiddenRegion)
-			formatInlineOrMultiline(document, astRegion, formattableRegion, mode,
+			formatInlineOrMultiline(document, astRegion, formattableRegion, mode.singleLineIf(f.eContainer instanceof ThenOperation),
 				[extension doc | // case: short inline function
 					f.body
 						.prepend[oneSpace]
-						.formatExpression(document, mode)
+						.formatExpression(doc, mode)
 					if (f.eContainer.eContainer instanceof RosettaOperation) {
 						// Always put next operations on a new line.
 						f.append[highPriority; newLine]
@@ -365,7 +367,7 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 						f.body
 							.prepend[newLine],
 						[indent]
-					).formatExpression(document, mode)
+					).formatExpression(doc, mode)
 				]
 			)
 		}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormatter.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormatter.xtend
@@ -305,8 +305,6 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 			mode,
 			[extension doc |
 				if (expr.function !== null) {
-					expr.regionFor.feature(ROSETTA_OPERATION__OPERATOR)
-						.append[oneSpace]
 					expr.function.formatInlineFunction(doc, mode.stopChain)
 				}
 			]
@@ -350,7 +348,20 @@ class RosettaExpressionFormatter extends AbstractRosettaFormatter2 {
 				]
 			)
 		} else { // case inline function without brackets
-			f.body.formatExpression(document, mode)
+			formatInlineOrMultiline(document, f.regionForEObject, mode,
+				[extension doc | // case: short inline function
+					f.body
+						.formatExpression(document, mode)
+					if (f.eContainer.eContainer instanceof RosettaOperation) {
+						// Always put next operations on a new line.
+						f.append[highPriority; newLine]
+					}
+				],
+				[extension doc | // case: long inline function
+					f.body
+						.formatExpression(document, mode)
+				]
+			)
 		}
 	}
 

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/TrimmedMaxLineWidthDocument.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/TrimmedMaxLineWidthDocument.java
@@ -78,6 +78,9 @@ public class TrimmedMaxLineWidthDocument extends SubDocument {
 		int lastOffset = 0;
 		StringBuilder result = new StringBuilder();
 		for (ITextReplacement r : list) {
+			if (r.getEndOffset() <= startOffset) {
+				continue;
+			}
 			if (r.getOffset() >= astRegion.getEndOffset()) {
 				break;
 			}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/TrimmedMaxLineWidthDocument.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/TrimmedMaxLineWidthDocument.java
@@ -11,7 +11,7 @@ import org.eclipse.xtext.formatting2.ITextReplacer;
 import org.eclipse.xtext.formatting2.ITextReplacerContext;
 import org.eclipse.xtext.formatting2.internal.HiddenRegionReplacer;
 import org.eclipse.xtext.formatting2.internal.SubDocument;
-import org.eclipse.xtext.formatting2.regionaccess.IAstRegion;
+import org.eclipse.xtext.formatting2.regionaccess.ISequentialRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 
 import com.google.common.collect.Lists;
@@ -24,9 +24,9 @@ import com.google.common.collect.Lists;
 public class TrimmedMaxLineWidthDocument extends SubDocument {
 	private final int maxLineWidth;
 	
-	private final IAstRegion astRegion;
+	private final ISequentialRegion astRegion;
 
-	public TrimmedMaxLineWidthDocument(IAstRegion region, IFormattableDocument parent, int maxLineWidth) {
+	public TrimmedMaxLineWidthDocument(ISequentialRegion region, IFormattableDocument parent, int maxLineWidth) {
 		super(region.merge(region.getNextHiddenRegion()), parent);
 		this.astRegion = region;
 		this.maxLineWidth = maxLineWidth;

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/TrimmedMaxLineWidthDocument.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/formatting2/TrimmedMaxLineWidthDocument.java
@@ -13,6 +13,7 @@ import org.eclipse.xtext.formatting2.internal.HiddenRegionReplacer;
 import org.eclipse.xtext.formatting2.internal.SubDocument;
 import org.eclipse.xtext.formatting2.regionaccess.ISequentialRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 
 import com.google.common.collect.Lists;
 
@@ -24,11 +25,15 @@ import com.google.common.collect.Lists;
 public class TrimmedMaxLineWidthDocument extends SubDocument {
 	private final int maxLineWidth;
 	
-	private final ISequentialRegion astRegion;
+	private final ITextSegment astRegion;
 
-	public TrimmedMaxLineWidthDocument(ISequentialRegion region, IFormattableDocument parent, int maxLineWidth) {
-		super(region.merge(region.getNextHiddenRegion()), parent);
-		this.astRegion = region;
+	public TrimmedMaxLineWidthDocument(ISequentialRegion astRegion, IFormattableDocument parent, int maxLineWidth) {
+		this(astRegion, astRegion.merge(astRegion.getNextHiddenRegion()), parent, maxLineWidth);
+	}
+	
+	public TrimmedMaxLineWidthDocument(ITextSegment astRegion, ITextSegment formattableRegion, IFormattableDocument parent, int maxLineWidth) {
+		super(formattableRegion, parent);
+		this.astRegion = astRegion;
 		this.maxLineWidth = maxLineWidth;
 	}
 

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/validation/RosettaIssueCodes.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/validation/RosettaIssueCodes.java
@@ -2,7 +2,7 @@ package com.regnosys.rosetta.validation;
 
 public interface RosettaIssueCodes {
 	
-	static final String PREFIX = RosettaIssueCodes.class.getName() + ".";
+	static final String PREFIX = "RosettaIssueCodes.";
 	
 	static final String DUPLICATE_ATTRIBUTE = PREFIX + "duplicateAttribute" ;
 	static final String DUPLICATE_ENUM_VALUE = PREFIX + "duplicateEnumValue";
@@ -23,4 +23,7 @@ public interface RosettaIssueCodes {
 	static final String INVALID_ELEMENT_NAME=PREFIX +"invalidElementName";
 	static final String UNUSED_IMPORT = PREFIX + "unusedImport";
 
+	static final String MANDATORY_SQUARE_BRACKETS = PREFIX + "mandatorySquareBrackets";
+	static final String REDUNDANT_SQUARE_BRACKETS = PREFIX + "redundantSquareBrackets";
+	static final String MANDATORY_THEN = PREFIX + "mandatoryThen";
 }

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormattingTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormattingTest.xtend
@@ -614,9 +614,10 @@ class RosettaExpressionFormattingTest {
 			then filter item = False
 		''' -> '''
 		FilterQuantity(quantity1, unitOfAmount)
-			extract FilterQuantity(quantity2, unitOfAmount)
-				extract q2 [ CompareNumbers(value, op, q2 -> value) ]
-				flatten
+			extract
+				FilterQuantity(quantity2, unitOfAmount)
+					extract q2 [ CompareNumbers(value, op, q2 -> value) ]
+					flatten
 			then filter item = False
 		'''
 	}

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormattingTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/formatting2/RosettaExpressionFormattingTest.xtend
@@ -51,6 +51,32 @@ class RosettaExpressionFormattingTest {
 	}
 	
 	@Test
+	def void testOperationChainingFormat() {
+		'''
+		input
+			extract [
+				item -> bar
+					filter "this is a loooooooooooong expression" count > 2
+			]
+			then extract
+				if True
+				then ["This is a looong", "expression"]
+				else 42
+		''' ->
+		'''
+		input
+			extract [
+				item -> bar
+					filter "this is a loooooooooooong expression" count > 2
+			]
+			then extract
+				if True
+				then ["This is a looong", "expression"]
+				else 42
+		'''
+	}
+	
+	@Test
 	def void testShortParenthesesAreFormatted() {
 		'''
 		(  

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOperationTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOperationTest.xtend
@@ -667,7 +667,7 @@ class ListOperationTest {
 				set filteredFoosCount:
 					foos 
 						filter fooItem [ fooItem -> include = True ] 
-						count
+						then count
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1094,7 +1094,7 @@ class ListOperationTest {
 				set filteredFoosOnlyElement:
 					foos 
 						filter fooItem [ fooItem -> include = True ]
-						only-element
+						then only-element
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1129,7 +1129,7 @@ class ListOperationTest {
 				set filteredFoosDistinct:
 					foos 
 						filter fooItem [ fooItem -> include = True ]
-						distinct
+						then distinct
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1208,7 +1208,7 @@ class ListOperationTest {
 					bars 
 						filter bar [ bar -> foos 
 							filter foo [ foo -> include = True ] 
-								count = 2 ]
+								then count = 2 ]
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1566,7 +1566,7 @@ class ListOperationTest {
 				set foos:
 					bars 
 						map bar [ bar -> foos ]
-						flatten
+						then flatten
 		'''
 		val code = model.generateCode
 		val f = code.get("com.rosetta.test.model.functions.FuncFoo")
@@ -1618,7 +1618,8 @@ class ListOperationTest {
 						protected List<Foo.FooBuilder> assignOutput(List<Foo.FooBuilder> foos, List<? extends Bar> bars) {
 							foos = toBuilder(MapperC.<Bar>of(bars)
 								.mapItemToList(bar -> (MapperC<Foo>)bar.<Foo>mapC("getFoos", _bar -> _bar.getFoos()))
-								.flattenList().getMulti());
+								.apply(item -> item
+									.flattenList()).getMulti());
 							
 							return Optional.ofNullable(foos)
 								.map(o -> o.stream().map(i -> i.prune()).collect(Collectors.toList()))
@@ -1666,7 +1667,7 @@ class ListOperationTest {
 				set foos:
 					bars 
 						map [ item -> foos ]
-						flatten
+						then flatten
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1706,8 +1707,8 @@ class ListOperationTest {
 				set attrs:
 					bars 
 						map [ item -> foos ]
-						flatten
-						map [ item -> attr ]
+						then flatten
+						then map [ item -> attr ]
 		'''
 		val code = model.generateCode
 				val f = code.get("com.rosetta.test.model.functions.FuncFoo")
@@ -1750,8 +1751,10 @@ class ListOperationTest {
 						protected List<String> assignOutput(List<String> attrs, List<? extends Bar> bars) {
 							attrs = MapperC.<Bar>of(bars)
 								.mapItemToList(item -> (MapperC<Foo>)item.<Foo>mapC("getFoos", bar -> bar.getFoos()))
-								.flattenList()
-								.mapItem(item -> (MapperS<String>)item.<String>map("getAttr", foo -> foo.getAttr())).getMulti();
+								.apply(item -> item
+									.flattenList())
+								.apply(item -> item
+									.mapItem(_item -> (MapperS<String>)_item.<String>map("getAttr", foo -> foo.getAttr()))).getMulti();
 							
 							return attrs;
 						}
@@ -2365,8 +2368,9 @@ class ListOperationTest {
 				
 				set strings:
 					bars 
-						map [ item -> foos ] flatten
-						map [ item -> attr ]
+						map [ item -> foos ]
+						then flatten
+						then map [ item -> attr ]
 		''']
 		val code = model.generateCode
 		val f = code.get("ns2.functions.FuncFoo")
@@ -2409,8 +2413,10 @@ class ListOperationTest {
 						protected List<String> assignOutput(List<String> strings, List<? extends Bar> bars) {
 							strings = MapperC.<Bar>of(bars)
 								.mapItemToList(item -> (MapperC<Foo>)item.<Foo>mapC("getFoos", bar -> bar.getFoos()))
-								.flattenList()
-								.mapItem(item -> (MapperS<String>)item.<String>map("getAttr", foo -> foo.getAttr())).getMulti();
+								.apply(item -> item
+									.flattenList())
+								.apply(item -> item
+									.mapItem(_item -> (MapperS<String>)_item.<String>map("getAttr", foo -> foo.getAttr()))).getMulti();
 							
 							return strings;
 						}

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOperationTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOperationTest.xtend
@@ -273,7 +273,7 @@ class ListOperationTest {
 				set filteredFoos:
 					foos 
 						filter [ item -> include = True ]
-						filter [ item -> include2 = True ]
+						then filter [ item -> include2 = True ]
 		'''
 		val code = model.generateCode
 		val f = code.get("com.rosetta.test.model.functions.FuncFoo")
@@ -327,7 +327,8 @@ class ListOperationTest {
 						protected List<Foo2.Foo2Builder> assignOutput(List<Foo2.Foo2Builder> filteredFoos, List<? extends Foo2> foos) {
 							filteredFoos = toBuilder(MapperC.<Foo2>of(foos)
 								.filterItem(item -> (Boolean)areEqual(item.<Boolean>map("getInclude", foo2 -> foo2.getInclude()), MapperS.of(Boolean.valueOf(true)), CardinalityOperator.All).get())
-								.filterItem(item -> (Boolean)areEqual(item.<Boolean>map("getInclude2", foo2 -> foo2.getInclude2()), MapperS.of(Boolean.valueOf(true)), CardinalityOperator.All).get()).getMulti());
+								.apply(item -> item
+									.filterItem(_item -> (Boolean)areEqual(_item.<Boolean>map("getInclude2", foo2 -> foo2.getInclude2()), MapperS.of(Boolean.valueOf(true)), CardinalityOperator.All).get())).getMulti());
 							
 							return Optional.ofNullable(filteredFoos)
 								.map(o -> o.stream().map(i -> i.prune()).collect(Collectors.toList()))
@@ -701,7 +702,7 @@ class ListOperationTest {
 				set filteredFoos:
 					foos 
 						filter [ FuncFooTest( item ) ]
-						filter [ FuncFooTest2( item ) ]
+						then filter [ FuncFooTest2( item ) ]
 			
 			func FuncFooTest:
 			 	inputs:
@@ -836,8 +837,8 @@ class ListOperationTest {
 				alias filteredFoos:
 					foos 
 						filter a [ if test exists then a -> include = test else True ]
-						filter b [ if test2 exists then b -> include2 = test2 else True ]
-						filter c [ if test3 exists then c -> include2 = test3 else True ]
+						then filter b [ if test2 exists then b -> include2 = test2 else True ]
+						then filter c [ if test3 exists then c -> include2 = test3 else True ]
 				
 				set foo:
 					filteredFoos only-element
@@ -879,8 +880,8 @@ class ListOperationTest {
 				alias filteredFoos:
 					foos 
 						filter [ if test exists then item -> include = test else True ]
-						filter [ if test2 exists then item -> include2 = test2 else True ]
-						filter [ if test3 exists then item -> include2 = test3 else True ]
+						then filter [ if test2 exists then item -> include2 = test2 else True ]
+						then filter [ if test3 exists then item -> include2 = test3 else True ]
 				
 				set foo:
 					filteredFoos only-element
@@ -1365,7 +1366,7 @@ class ListOperationTest {
 				set fooCounts:
 					bars 
 						map bar [ bar -> foos ]
-						map fooListItem [ fooListItem count ]
+						then map fooListItem [ fooListItem count ]
 		'''
 		val code = model.generateCode
 		val f = code.get("com.rosetta.test.model.functions.FuncFoo")
@@ -1408,7 +1409,8 @@ class ListOperationTest {
 						protected List<Integer> assignOutput(List<Integer> fooCounts, List<? extends Bar> bars) {
 							fooCounts = MapperC.<Bar>of(bars)
 								.mapItemToList(bar -> (MapperC<Foo>)bar.<Foo>mapC("getFoos", _bar -> _bar.getFoos()))
-								.mapListToItem(fooListItem -> (MapperS<Integer>)MapperS.of(fooListItem.resultCount())).getMulti();
+								.apply(item -> item
+									.mapListToItem(fooListItem -> (MapperS<Integer>)MapperS.of(fooListItem.resultCount()))).getMulti();
 							
 							return fooCounts;
 						}
@@ -1451,7 +1453,7 @@ class ListOperationTest {
 				set fooCounts:
 					bars 
 						map [ item -> foos ]
-						map [ item count ]
+						then map [ item count ]
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1488,8 +1490,8 @@ class ListOperationTest {
 				set fooCounts:
 					bars 
 						map [ item -> foos ]
-						filter [ item count > 1 ]
-						map [ item count ]
+						then filter [ item count > 1 ]
+						then map [ item count ]
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1526,8 +1528,8 @@ class ListOperationTest {
 				set fooCounts:
 					bars 
 						map a [ a -> foos ]
-						filter b [ b count > 1 ]
-						map c [ c count ]
+						then filter b [ b count > 1 ]
+						then map c [ c count ]
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -1869,7 +1871,7 @@ class ListOperationTest {
 						map bar [ bar -> foos 
 							map foo [ NewFoo( foo -> attr + "_bar" ) ]
 						]
-						map updatedFoos [ NewBar( updatedFoos ) ]
+						then map updatedFoos [ NewBar( updatedFoos ) ]
 			
 			func NewBar:
 			 	inputs:
@@ -1947,7 +1949,8 @@ class ListOperationTest {
 							updatedBars = toBuilder(MapperC.<Bar>of(bars)
 								.mapItemToList(bar -> (MapperC<Foo>)bar.<Foo>mapC("getFoos", _bar -> _bar.getFoos())
 									.mapItem(foo -> (MapperS<Foo>)MapperS.of(newFoo.evaluate(MapperMaths.<String, String, String>add(foo.<String>map("getAttr", _foo -> _foo.getAttr()), MapperS.of("_bar")).get()))))
-								.mapListToItem(updatedFoos -> (MapperS<Bar>)MapperS.of(newBar.evaluate(updatedFoos.getMulti()))).getMulti());
+								.apply(item -> item
+									.mapListToItem(updatedFoos -> (MapperS<Bar>)MapperS.of(newBar.evaluate(updatedFoos.getMulti())))).getMulti());
 							
 							return Optional.ofNullable(updatedBars)
 								.map(o -> o.stream().map(i -> i.prune()).collect(Collectors.toList()))
@@ -2180,7 +2183,7 @@ class ListOperationTest {
 				set newFoos:
 					foos 
 						filter [ item -> include = True ]
-						map [ item -> attr ]
+						then map [ item -> attr ]
 
 		'''
 		val code = model.generateCode
@@ -2225,7 +2228,8 @@ class ListOperationTest {
 						protected List<String> assignOutput(List<String> newFoos, List<? extends Foo> foos) {
 							newFoos = MapperC.<Foo>of(foos)
 								.filterItem(item -> (Boolean)areEqual(item.<Boolean>map("getInclude", foo -> foo.getInclude()), MapperS.of(Boolean.valueOf(true)), CardinalityOperator.All).get())
-								.mapItem(item -> (MapperS<String>)item.<String>map("getAttr", foo -> foo.getAttr())).getMulti();
+								.apply(item -> item
+									.mapItem(_item -> (MapperS<String>)_item.<String>map("getAttr", foo -> foo.getAttr()))).getMulti();
 							
 							return newFoos;
 						}
@@ -2277,7 +2281,7 @@ class ListOperationTest {
 				set strings:
 					bars 
 						map [ GetFoo( item -> barAttr ) ]
-						map [ item -> fooAttr ]
+						then map [ item -> fooAttr ]
 		'''
 		val code = model.generateCode
 		val f = code.get("ns1.functions.FuncFoo")
@@ -2325,7 +2329,8 @@ class ListOperationTest {
 						protected List<String> assignOutput(List<String> strings, List<? extends Bar> bars) {
 							strings = MapperC.<Bar>of(bars)
 								.mapItem(item -> (MapperS<Foo>)MapperS.of(getFoo.evaluate(item.<String>map("getBarAttr", bar -> bar.getBarAttr()).get())))
-								.mapItem(item -> (MapperS<String>)item.<String>map("getFooAttr", foo -> foo.getFooAttr())).getMulti();
+								.apply(item -> item
+									.mapItem(_item -> (MapperS<String>)_item.<String>map("getFooAttr", foo -> foo.getFooAttr()))).getMulti();
 							
 							return strings;
 						}
@@ -2447,7 +2452,7 @@ class ListOperationTest {
 				set strings:
 					bars 
 						map [ GetFoo( item -> barAttr ) ]
-						map [ item -> fooAttr ]
+						then map [ item -> fooAttr ]
 		''']
 		val code = model.generateCode
 		val f = code.get("ns2.functions.FuncFoo")
@@ -2496,7 +2501,8 @@ class ListOperationTest {
 						protected List<String> assignOutput(List<String> strings, List<? extends Bar> bars) {
 							strings = MapperC.<Bar>of(bars)
 								.mapItem(item -> (MapperS<Foo>)MapperS.of(getFoo.evaluate(item.<String>map("getBarAttr", bar -> bar.getBarAttr()).get())))
-								.mapItem(item -> (MapperS<String>)item.<String>map("getFooAttr", foo -> foo.getFooAttr())).getMulti();
+								.apply(item -> item
+									.mapItem(_item -> (MapperS<String>)_item.<String>map("getFooAttr", foo -> foo.getFooAttr()))).getMulti();
 							
 							return strings;
 						}
@@ -2547,7 +2553,7 @@ class ListOperationTest {
 				set strings:
 					bars 
 						map [ GetFoo( GetBaz( item -> barAttr ) ) ]
-						map [ item -> fooAttr ]
+						then map [ item -> fooAttr ]
 		''']
 		val code = model.generateCode
 		val f = code.get("ns2.functions.FuncFoo")
@@ -2598,7 +2604,8 @@ class ListOperationTest {
 						protected List<String> assignOutput(List<String> strings, List<? extends Bar> bars) {
 							strings = MapperC.<Bar>of(bars)
 								.mapItem(item -> (MapperS<Foo>)MapperS.of(getFoo.evaluate(MapperS.of(getBaz.evaluate(item.<String>map("getBarAttr", bar -> bar.getBarAttr()).get())).get())))
-								.mapItem(item -> (MapperS<String>)item.<String>map("getFooAttr", foo -> foo.getFooAttr())).getMulti();
+								.apply(item -> item
+									.mapItem(_item -> (MapperS<String>)_item.<String>map("getFooAttr", foo -> foo.getFooAttr()))).getMulti();
 							
 							return strings;
 						}
@@ -3358,7 +3365,7 @@ class ListOperationTest {
 				set fooCount:
 					bars
 						reduce bar1, bar2 [ if bar1 -> foos count > bar2 -> foos count then bar1 else bar2 ]
-						map [ item -> foos count ]
+						then map [ item -> foos count ]
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses
@@ -3402,8 +3409,8 @@ class ListOperationTest {
 				set attrs:
 					bars
 						reduce bar1, bar2 [ if bar1 -> foos count > bar2 -> foos count then bar1 else bar2 ] // max by foo count
-						map [ item -> foos ]
-						map [ item -> attr ]
+						then map [ item -> foos ]
+						then map [ item -> attr ]
 		'''
 		val code = model.generateCode
 		val classes = code.compileToClasses

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
@@ -330,8 +330,8 @@ class FunctionGeneratorTest {
 				add res:
 					list
 						extract Incr
-						extract Incr
-						extract [ item + 1 ]
+						then extract Incr
+						then extract item + 1
 						then a [ a extract Incr ]
 		'''.generateCode
 		val classes = code.compileToClasses
@@ -453,8 +453,8 @@ class FunctionGeneratorTest {
 					res boolean (1..1)
 				set res:
 					42
-						extract [item + 1]
-						extract [item = 42]
+						extract item + 1
+						then extract item = 42
 		'''.generateCode
 		val classes = code.compileToClasses
 

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/tests/RosettaParsingTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/tests/RosettaParsingTest.xtend
@@ -157,18 +157,18 @@ class RosettaParsingTest {
 					foo
 						extract if F(bar only-element) = True and bar only-element -> a first = "bar"
 							then bar
-					    then extract item -> a
+					    then extract [ item -> a
 					    	filter [<> "foo"]
-					    	only-element
+					    	then only-element ]
 					    then extract item + "bar"
 				
 				set result:
 					((foo
 						extract (if ((F(bar only-element) = True) and (((bar only-element) -> a) first = "bar"))
 							then bar))
-					    then (extract (((item -> a)
+					    then (extract [(((item -> a)
 					    	filter [<> "foo"])
-					    	only-element)))
+					    	then only-element)]))
 					    then (extract (item + "bar"))
 		'''.parseRosettaWithNoErrors
 		model.elements.last as Function => [

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/tests/RosettaParsingTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/tests/RosettaParsingTest.xtend
@@ -217,7 +217,7 @@ class RosettaParsingTest {
 					a int (1..1)
 				output: result int (1..1)
 				set result:
-					foo extract [ a ]
+					foo extract a
 		'''.parseRosettaWithNoIssues
 		
 		model.elements.last as Function => [
@@ -277,8 +277,8 @@ class RosettaParsingTest {
                
                condition C:
                    [deprecated] // the parser should parse this as an annotation, not a list
-                   extract [it -> a]
-                   then [ exists ]
+                   extract it -> a
+                   then exists
            
            func F:
                inputs:
@@ -286,11 +286,10 @@ class RosettaParsingTest {
                output:
                    result boolean (1..1)
                set result:
-                   a extract [
+                   a extract
                        if F
                        then False
                        else True and F
-                   ]
 	    '''.parseRosetta
 
 	    model.elements.head as Data => [

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/types/RosettaTypingTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/types/RosettaTypingTest.xtend
@@ -71,7 +71,7 @@ class RosettaTypingTest {
 		func TestImplicitVar:
 			output: result int (3..3)
 			add result:
-				[1, 2, 3] map [item + 1]
+				[1, 2, 3] map item + 1
 		'''.parseRosettaWithNoIssues
 		model.elements.get(0) as Function => [operations.head.expression as RosettaConditionalExpression => [
 			^if.assertHasType(singleBoolean)


### PR DESCRIPTION
This PR includes making the usage of `then` mandatory in certain cases, while making the use of square brackets unnecessary in most cases. See https://github.com/REGnosys/rosetta-dsl/issues/569 for details.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

Fixes https://github.com/REGnosys/rosetta-dsl/issues/569