### PR TITLE
Input validation for legacy rules; various patches for validation, code generation and logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>org.eclipse.xtext</artifactId>
 				<version>${xtext.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xtext</groupId>
@@ -126,6 +132,12 @@
 				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>org.eclipse.xtext.util</artifactId>
 				<version>${xtext.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xtend</groupId>
@@ -146,6 +158,12 @@
 				<groupId>org.eclipse.emf</groupId>
 				<artifactId>org.eclipse.emf.ecore.xcore</artifactId>
 				<version>${org.eclipse.emf.ecore.xcore.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>log4j</groupId>
+						<artifactId>log4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.emf</groupId>
@@ -156,6 +174,12 @@
 				<groupId>org.eclipse.xsemantics</groupId>
 				<artifactId>org.eclipse.xsemantics.runtime</artifactId>
 				<version>${xsemantics.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xsemantics</groupId>
@@ -186,17 +210,24 @@
 				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtext-maven-plugin</artifactId>
 				<version>${xtext.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.version}</version>
 			</dependency>
-			<!-- Xtext uses Log4j directly. The following dependency will redirect Log4j messages to slf4j. -->
+			<!-- Xtext uses Log4j directly. The following dependency will
+			redirect Log4j messages to slf4j. -->
 			<dependency>
-			    <groupId>org.slf4j</groupId>
-			    <artifactId>log4j-over-slf4j</artifactId>
-			    <version>${slf4j.version}</version>
+				<groupId>org.slf4j</groupId>
+				<artifactId>log4j-over-slf4j</artifactId>
+				<version>${slf4j.version}</version>
 			</dependency>
 
 			<!-- Test dependencies -->
@@ -238,18 +269,18 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>log4j-over-slf4j</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -270,6 +301,13 @@
 								<requireJavaVersion>
 									<version>${java.enforced.version}</version>
 								</requireJavaVersion>
+								<bannedDependencies>
+									<excludes>
+										<exclude>log4j:log4j</exclude>
+										<exclude>org.apache.logging.log4j:log4j-core</exclude>
+										<exclude>ch.qos.reload4j:reload4j</exclude>
+									</excludes>
+								</bannedDependencies>
 							</rules>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -37,14 +37,13 @@
 		<maven-plugin-api.version>3.6.0</maven-plugin-api.version>
 		<maven-core.version>3.6.0</maven-core.version>
 		<maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
-		<slf4j-api.version>2.0.7</slf4j-api.version>
-		<reload4j.version>1.2.24</reload4j.version>
+		<slf4j.version>2.0.7</slf4j.version>
 		<log4j-over-slf4j.version>2.0.7</log4j-over-slf4j.version>
+		<logback.version>1.4.7</logback.version>
 
 		<!-- test -->
 		<junit.version>5.8.2</junit.version>
 		<mockito-core.version>5.1.1</mockito-core.version>
-		<logback.version>1.4.7</logback.version>
 
 		<!-- Plugin and plugin dependency management -->
 		<org.eclipse.emf.ecore.xcore.version>1.23.0</org.eclipse.emf.ecore.xcore.version>
@@ -191,18 +190,13 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>${slf4j-api.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>ch.qos.reload4j</groupId>
-				<artifactId>reload4j</artifactId>
-				<version>${reload4j.version}</version>
+				<version>${slf4j.version}</version>
 			</dependency>
 			<!-- Xtext uses Log4j directly. The following dependency will redirect Log4j messages to slf4j. -->
 			<dependency>
 			    <groupId>org.slf4j</groupId>
 			    <artifactId>log4j-over-slf4j</artifactId>
-			    <version>${log4j-over-slf4j.version}</version>
+			    <version>${slf4j.version}</version>
 			</dependency>
 
 			<!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
 		<slf4j-api.version>2.0.7</slf4j-api.version>
 		<reload4j.version>1.2.24</reload4j.version>
+		<log4j-over-slf4j.version>2.0.7</log4j-over-slf4j.version>
 
 		<!-- test -->
 		<junit.version>5.8.2</junit.version>
@@ -197,6 +198,12 @@
 				<artifactId>reload4j</artifactId>
 				<version>${reload4j.version}</version>
 			</dependency>
+			<!-- Xtext uses Log4j directly. The following dependency will redirect Log4j messages to slf4j. -->
+			<dependency>
+			    <groupId>org.slf4j</groupId>
+			    <artifactId>log4j-over-slf4j</artifactId>
+			    <version>${log4j-over-slf4j.version}</version>
+			</dependency>
 
 			<!-- Test dependencies -->
 			<dependency>
@@ -221,13 +228,11 @@
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-core</artifactId>
 				<version>${logback.version}</version>
-				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -237,6 +242,20 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>log4j-over-slf4j</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/rosetta-ide/pom.xml
+++ b/rosetta-ide/pom.xml
@@ -46,16 +46,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/inlayhints/RosettaInlayHintsService.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/inlayhints/RosettaInlayHintsService.java
@@ -59,6 +59,9 @@ public class RosettaInlayHintsService extends AbstractInlayHintsService {
 	private boolean operationHasBrackets(InlineFunction op) {
 		Keyword keyword = grammar.getInlineFunctionAccess().getLeftSquareBracketKeyword_0_0_1();
 		ICompositeNode node = NodeModelUtils.findActualNodeFor(op);
+		if (node == null) {
+			return false;
+		}
 
         for (INode n : node.getChildren()) {
             EObject ge = n.getGrammarElement();

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/inlayhints/RosettaInlayHintsService.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/inlayhints/RosettaInlayHintsService.java
@@ -12,11 +12,11 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 
 import com.regnosys.rosetta.RosettaExtensions;
 import com.regnosys.rosetta.types.CardinalityProvider;
+import com.regnosys.rosetta.rosetta.RosettaBlueprint;
 import com.regnosys.rosetta.rosetta.expression.InlineFunction;
 import com.regnosys.rosetta.rosetta.expression.MapOperation;
 import com.regnosys.rosetta.rosetta.expression.ReduceOperation;
 import com.regnosys.rosetta.rosetta.expression.RosettaFunctionalOperation;
-import com.regnosys.rosetta.rosetta.simple.Function;
 import com.regnosys.rosetta.services.RosettaGrammarAccess;
 import com.regnosys.rosetta.types.RType;
 import com.regnosys.rosetta.types.RosettaTypeProvider;
@@ -41,14 +41,17 @@ public class RosettaInlayHintsService extends AbstractInlayHintsService {
 	
 	@InlayHintCheck
 	public InlayHint checkFunctionalOperation(RosettaFunctionalOperation op) {
-		if (EcoreUtil2.getContainerOfType(op, Function.class) != null && operationHasBrackets(op.getFunction())) {
-			if (op instanceof ReduceOperation || op instanceof MapOperation) {
-				if (extensions.isResolved(op.getFunction())) {
-					RType outputType = types.getRType(op);
-					boolean outputMulti = card.isMulti(op);
-		
-					if (outputType != null) {
-						return inlayHintAfter(op, typeInfo(outputType, outputMulti), null);
+		RosettaBlueprint rule = EcoreUtil2.getContainerOfType(op, RosettaBlueprint.class);
+		if (rule == null || !rule.isLegacy()) {
+			if (op.getFunction() != null && operationHasBrackets(op.getFunction())) {
+				if (op instanceof ReduceOperation || op instanceof MapOperation) {
+					if (extensions.isResolved(op.getFunction())) {
+						RType outputType = types.getRType(op);
+						boolean outputMulti = card.isMulti(op);
+			
+						if (outputType != null) {
+							return inlayHintAfter(op, typeInfo(outputType, outputMulti), null);
+						}
 					}
 				}
 			}
@@ -59,9 +62,6 @@ public class RosettaInlayHintsService extends AbstractInlayHintsService {
 	private boolean operationHasBrackets(InlineFunction op) {
 		Keyword keyword = grammar.getInlineFunctionAccess().getLeftSquareBracketKeyword_0_0_1();
 		ICompositeNode node = NodeModelUtils.findActualNodeFor(op);
-		if (node == null) {
-			return false;
-		}
 
         for (INode n : node.getChildren()) {
             EObject ge = n.getGrammarElement();

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/blueprints/BlueprintGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/blueprints/BlueprintGenerator.xtend
@@ -114,7 +114,7 @@ class BlueprintGenerator {
 			.filter[nodes !== null]
 			.forEach [ bp |
 			fsa.generateFile(root.blueprint.withForwardSlashes + '/' + bp.name + 'Rule.java',
-				generateBlueprint(root, bp.nodes, bp.name, 'Rule', bp.URI, null, version))
+				generateBlueprint(root, bp, bp.name, 'Rule', bp.URI, null, version))
 		]
 		elements.filter(RosettaBlueprint)
 			.filter[!isLegacy]
@@ -165,17 +165,21 @@ class BlueprintGenerator {
 			orNodeExpr.node = node
 			currentNodeExpr.next = orNodeExpr			
 		}
+		
+		val rule = RosettaFactory.eINSTANCE.createRosettaBlueprint
+		rule.legacy = true
+		rule.nodes = firstNodeExpr
 			
-		return firstNodeExpr
+		return rule
 	}
 
 	/**
 	 * Generate the text of a blueprint
 	 */
-	def generateBlueprint(RootPackage packageName, BlueprintNodeExp nodes, String name, String type, String uri, String dataItemReportBuilderName, String version) {
+	def generateBlueprint(RootPackage packageName, RosettaBlueprint rule, String name, String type, String uri, String dataItemReportBuilderName, String version) {
 		try {
 			
-			val typed = buildTypeGraph(nodes)
+			val typed = buildTypeGraph(rule)
 			val clazz = new JavaClass(packageName.blueprint, name + type)
 			val typedJava = typed.toJavaNode(clazz)
 			val clazzWithArgs = typedJava.toParametrizedType(clazz)
@@ -205,7 +209,7 @@ class BlueprintGenerator {
 						return "«uri»";
 					}
 					
-					«nodes.buildBody(classScope, typedJava, dataItemReportBuilderName)»
+					«rule.nodes.buildBody(classScope, typedJava, dataItemReportBuilderName)»
 				}
 				'''
 
@@ -220,7 +224,7 @@ class BlueprintGenerator {
 	def nonLegacyGenerateBlueprint(JavaClass ruleClass, RosettaBlueprint rule, String version) {
 		try {
 			
-			val typed = nonLegacyBuildTypeGraph(rule.expression)
+			val typed = buildTypeGraph(rule)
 			val typedJava = typed.toJavaNode(ruleClass)
 			val clazzWithArgs = typedJava.toParametrizedType(ruleClass)
 

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/blueprints/BlueprintGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/blueprints/BlueprintGenerator.xtend
@@ -585,8 +585,6 @@ class BlueprintGenerator {
 			return '''new «RuleIdentifier»("«rule.identifier»", getClass())'''
 		}
 		return '''null'''
-		// val nodeName = rule.expression.toNodeLabel
-		// return '''new «RuleIdentifier»("«nodeName»", getClass())'''
 	}
 	
 	static def getURI(EObject eObject) {

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/ExpressionGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/ExpressionGenerator.xtend
@@ -918,16 +918,7 @@ class ExpressionGenerator {
 		}
 		
 		val receiver = call.receiver
-		val left = switch receiver {
-			RosettaReference,
-			RosettaFeatureCall: {
-				toNodeLabel(receiver)
-			}
-			RosettaOnlyElement : {
-				toNodeLabel(receiver.argument)
-			}
-			default: throw new UnsupportedOperationException("Unsupported expression type (receiver) " + receiver?.getClass)
-		}
+		val left = receiver.toNodeLabel
 		
 		'''«left»->«right»'''
 	}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/types/RosettaTypeProvider.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/types/RosettaTypeProvider.xtend
@@ -130,7 +130,7 @@ class RosettaTypeProvider {
 		switch (feature) {
 			RosettaTypedFeature: {
 				val featureType = if (feature.isTypeInferred) {
-						feature.safeRType(cycleTracker)
+						new RErrorType("Cannot infer type of feature.")
 					} else {
 						feature.typeCall.typeCallToRType
 					}

--- a/rosetta-testing/pom.xml
+++ b/rosetta-testing/pom.xml
@@ -39,16 +39,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/blueprints/RosettaBlueprintTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/blueprints/RosettaBlueprintTest.xtend
@@ -2927,7 +2927,7 @@ class RosettaBlueprintTest {
 				Bar
 				Baz
 			
-			reporting rule ReturnEnumValue from ReportableEvent:
+			reporting rule ReturnEnumValue from number:
 				[legacy-syntax]
 				return FooEnum -> Bar
 			

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.xtend
@@ -31,6 +31,18 @@ class RosettaValidatorTest implements RosettaIssueCodes {
 	@Inject extension ModelHelper
 	
 	@Test
+	def void inputTypeOfLegacyRuleIsChecked() {
+		val model = '''
+		reporting rule Foo from number:
+			[legacy-syntax]
+			extract ReportableEvent
+		'''.parseRosetta
+		
+		model.assertError(BLUEPRINT_EXTRACT, TYPE_ERROR,
+			"Input type of ReportableEvent is not assignable from type number of previous node")
+	}
+	
+	@Test
 	def void cannotCallARuleFromAFunction() {
 		val model = '''		
 		func Bar:

--- a/rosetta-tools/pom.xml
+++ b/rosetta-tools/pom.xml
@@ -78,15 +78,5 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/rosetta-xcore-plugin-dependencies/.classpath
+++ b/rosetta-xcore-plugin-dependencies/.classpath
@@ -62,5 +62,10 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/rosetta-xcore-plugin-dependencies/pom.xml
+++ b/rosetta-xcore-plugin-dependencies/pom.xml
@@ -37,6 +37,12 @@
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
+            <exclusions>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+			</exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.xtext</groupId>

--- a/rosetta-xcore-plugin-dependencies/pom.xml
+++ b/rosetta-xcore-plugin-dependencies/pom.xml
@@ -50,5 +50,13 @@
 	        <groupId>com.google.inject</groupId>
 	        <artifactId>guice</artifactId>
 	    </dependency>
+	    <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/rosetta-xcore-plugin-dependencies/src/main/resources/logback.xml
+++ b/rosetta-xcore-plugin-dependencies/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Send messages to System.out -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- By default, encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>[%level] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- By default, the level of the root level is set to DEBUG -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Enabled input type validation for legacy rules.
A patch for generating legacy blueprint node labels.
Various patches for unexpected errors (mostly NPEs) while validating a partial model or when running IDE services.
Patch for redirecting Xtext's logging to SLF4j.

## Type of change

- Non-breaking feature
- Bug fix (non-breaking change which fixes an issue)
