### PR TITLE
Allow test on multiple platforms

### DIFF
--- a/rosetta-tools/src/test/java/com/regnosys/rosetta/tools/modelimport/XsdImportTest.java
+++ b/rosetta-tools/src/test/java/com/regnosys/rosetta/tools/modelimport/XsdImportTest.java
@@ -95,12 +95,13 @@ public class XsdImportTest {
 		assertEquals(new HashSet<>(expectedResources), new HashSet<>(resourceNames));
 		
 		for (String resource: expectedResources) {
-			String expected = Resources.toString(Resources.getResource(expectedFolder + "/" + resource), StandardCharsets.UTF_8);
+			String expected = Resources.toString(Resources.getResource(expectedFolder + "/" + resource), StandardCharsets.UTF_8)
+					.replaceAll("\n", System.lineSeparator());
 			
 			Resource actualResource = set.getResource(URI.createURI(resource), false);
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			actualResource.save(output, null);
-			String actual = new String(output.toByteArray(), StandardCharsets.UTF_8).replaceAll("\r\n", "\n");
+			String actual = new String(output.toByteArray(), StandardCharsets.UTF_8);
 			
 			assertEquals(expected, actual);
 		}
@@ -110,9 +111,10 @@ public class XsdImportTest {
 		// Test XML config
 		RosettaXMLConfiguration xmlConfig = xsdImport.generateXMLConfiguration(schema, properties);
 		
-		String expected = Resources.toString(Resources.getResource(expectedFolder + "/xml-config.json"), StandardCharsets.UTF_8);
+		String expected = Resources.toString(Resources.getResource(expectedFolder + "/xml-config.json"), StandardCharsets.UTF_8)
+				.replaceAll("\n", System.lineSeparator());
 		ObjectMapper mapper = XsdImportMain.getObjectMapper();
-		String actual = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(xmlConfig).replaceAll("\r\n", "\n");
+		String actual = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(xmlConfig);
 		assertEquals(expected, actual);
 		
 		// Test deserialisation

--- a/rosetta-tools/src/test/java/com/regnosys/rosetta/tools/modelimport/XsdImportTest.java
+++ b/rosetta-tools/src/test/java/com/regnosys/rosetta/tools/modelimport/XsdImportTest.java
@@ -100,7 +100,7 @@ public class XsdImportTest {
 			Resource actualResource = set.getResource(URI.createURI(resource), false);
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			actualResource.save(output, null);
-			String actual = new String(output.toByteArray(), StandardCharsets.UTF_8);
+			String actual = new String(output.toByteArray(), StandardCharsets.UTF_8).replaceAll("\r\n", "\n");
 			
 			assertEquals(expected, actual);
 		}
@@ -112,7 +112,7 @@ public class XsdImportTest {
 		
 		String expected = Resources.toString(Resources.getResource(expectedFolder + "/xml-config.json"), StandardCharsets.UTF_8);
 		ObjectMapper mapper = XsdImportMain.getObjectMapper();
-		String actual = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(xmlConfig);
+		String actual = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(xmlConfig).replaceAll("\r\n", "\n");
 		assertEquals(expected, actual);
 		
 		// Test deserialisation


### PR DESCRIPTION
When running tests on a windows platform, files are created with local platform end of line character. On the other hand, the expected result of the test are static files (arbitrarily) containing *LF* end of line.

## Possible approaches
I chose to change the end of line characters in the expected output for the test, replacing them by the *platform* one.

Other possibilities include:
- change the actual generation to generate with a common end of line -> this would change the actual behavior of rosetta (although in a minor way). Generated files on windows platform would not match what the user would expect so I rejected that
- change the *actual* result (first commit) in the test by replacing the *platform* end of line by the *arbitrary* one. It seems less coherent to change that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
