### PR TITLE
Improved stability of language server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
 		<build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 		<maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
 		<maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 		<maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
@@ -394,6 +395,18 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 
 		<pluginManagement>
@@ -484,6 +497,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>${maven-plugin-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>${maven-source-plugin.version}</version>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
 				<plugin>

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/RosettaIdeModule.xtend
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/RosettaIdeModule.xtend
@@ -24,6 +24,12 @@ import org.eclipse.xtext.ide.editor.quickfix.IQuickFixProvider
 import com.regnosys.rosetta.ide.quickfix.RosettaQuickFixProvider
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2
 import com.regnosys.rosetta.ide.quickfix.RosettaQuickFixCodeActionService
+import org.eclipse.xtext.ide.server.contentassist.ContentAssistService
+import org.eclipse.xtext.service.OperationCanceledManager
+import com.regnosys.rosetta.ide.contentassist.cancellable.ICancellableContentAssistParser
+import com.regnosys.rosetta.ide.contentassist.cancellable.CancellableRosettaParser
+import com.regnosys.rosetta.ide.contentassist.cancellable.CancellableContentAssistService
+import com.regnosys.rosetta.ide.contentassist.cancellable.RosettaOperationCanceledManager
 
 /**
  * Use this class to register ide components.
@@ -76,5 +82,17 @@ class RosettaIdeModule extends AbstractRosettaIdeModule {
 	
 	def Class<? extends ICodeActionService2> bindICodeActionService2() {
 		RosettaQuickFixCodeActionService
+	}
+	
+	def Class<? extends ICancellableContentAssistParser> bindICancellableContentAssistParser() {
+		CancellableRosettaParser
+	}
+	
+	def Class<? extends ContentAssistService> bindContentAssistService() {
+		CancellableContentAssistService
+	}
+	
+	def Class<? extends OperationCanceledManager> bindOperationCanceledManager() {
+		RosettaOperationCanceledManager
 	}
 }

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableContentAssistContextFactory.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableContentAssistContextFactory.java
@@ -1,0 +1,115 @@
+package com.regnosys.rosetta.ide.contentassist.cancellable;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.Token;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.ContentAssistContextFactory;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.ITextRegion;
+import org.eclipse.xtext.util.Strings;
+
+/**
+ * A patch of Xtext's `ContentAssistContextFactory` which makes a completion request cancellable.
+ * TODO: contribute to Xtext.
+ */
+public class CancellableContentAssistContextFactory extends ContentAssistContextFactory {
+	private CancelIndicator cancelIndicator;
+	private String document;
+	
+	@Inject
+	protected ICancellableContentAssistParser cancellableParser;
+	
+	@Inject
+	private OperationCanceledManager operationCanceledManager;
+	
+	public void setCancelIndicator(CancelIndicator cancelIndicator) {
+		this.cancelIndicator = cancelIndicator;
+	}
+	
+	@Override
+	public ContentAssistContext[] create(String document, ITextRegion selection, int offset, XtextResource resource) {
+		this.document = document;
+		return super.create(document, selection, offset, resource);
+	}
+	
+	@Override
+	protected ContentAssistContext[] doCreateContexts(int offset) {
+		ContentAssistContext[] result = super.doCreateContexts(offset);
+		operationCanceledManager.checkCanceled(cancelIndicator);
+		return result;
+	}
+	
+	// Patch of super.handleLastCompleteNodeIsAtEndOfDatatypeNode
+	// that uses the custom `getFollowElements` method.
+	@Override
+	protected void handleLastCompleteNodeIsAtEndOfDatatypeNode() {
+		String prefix = getPrefix(lastCompleteNode);
+		String completeInput = getInputToParse(lastCompleteNode);
+		INode previousNode = getLastCompleteNodeByOffset(rootNode, lastCompleteNode.getOffset());
+		EObject previousModel = previousNode.getSemanticElement();
+		INode currentDatatypeNode = getContainingDatatypeRuleNode(currentNode);
+		Collection<FollowElement> followElements = getFollowElements(completeInput, false);
+		int prevSize = contextBuilders.size();
+		doCreateContexts(previousNode, currentDatatypeNode, prefix, previousModel, followElements);
+		
+		if (lastCompleteNode instanceof ILeafNode && lastCompleteNode.getGrammarElement() == null && contextBuilders.size() != prevSize) {
+			handleLastCompleteNodeHasNoGrammarElement(contextBuilders.subList(prevSize, contextBuilders.size()), previousModel);
+		}
+	}
+	
+	// Patch of super.handleLastCompleteNodeAsPartOfDatatypeNode
+	// that uses the custom `getFollowElements` method.
+	@Override
+	protected void handleLastCompleteNodeAsPartOfDatatypeNode() {
+		String prefix = getPrefix(datatypeNode);
+		String completeInput = getInputToParse(datatypeNode);
+		Collection<FollowElement> followElements = getFollowElements(completeInput, false);
+		INode lastCompleteNodeBeforeDatatype = getLastCompleteNodeByOffset(rootNode, datatypeNode.getTotalOffset());
+		doCreateContexts(lastCompleteNodeBeforeDatatype, datatypeNode, prefix, currentModel, followElements);
+	}
+	
+	// Patch of super.createContextsForLastCompleteNode
+	// that uses the custom `getFollowElements` method.
+	@Override
+	protected void createContextsForLastCompleteNode(EObject previousModel, boolean strict) {
+		String currentNodePrefix = getPrefix(currentNode);
+		if (!Strings.isEmpty(currentNodePrefix) && !currentNode.getText().equals(currentNodePrefix)) {
+			lexer.setCharStream(new ANTLRStringStream(currentNodePrefix));
+			Token token = lexer.nextToken();
+			if (token == Token.EOF_TOKEN) { // error case - nothing could be parsed
+				return;
+			}
+			while(token != Token.EOF_TOKEN) {
+				if (isErrorToken(token))
+					return;
+				token = lexer.nextToken();
+			}
+		}
+		String prefix = "";
+		String completeInput = getInputToParse(document, completionOffset);
+		Collection<FollowElement> followElements = getFollowElements(completeInput, strict);
+		doCreateContexts(lastCompleteNode, currentNode, prefix, previousModel, followElements);
+	}
+	
+	private Collection<FollowElement> getFollowElements(String completeInput, boolean strict) {
+		try {
+			return cancellableParser.getFollowElements(completeInput, strict, cancelIndicator);
+		} catch(Exception ex) {
+			if (operationCanceledManager.isOperationCanceledException(ex)) {
+				return Collections.emptyList();
+			}
+			throw ex;
+		}
+	}
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableContentAssistService.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableContentAssistService.java
@@ -1,0 +1,85 @@
+package com.regnosys.rosetta.ide.contentassist.cancellable;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext;
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistEntry;
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor;
+import org.eclipse.xtext.ide.editor.contentassist.IdeContentProposalAcceptor;
+import org.eclipse.xtext.ide.editor.contentassist.IdeContentProposalProvider;
+import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.ide.server.contentassist.ContentAssistService;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.TextRegion;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+
+import com.google.common.base.Strings;
+
+public class CancellableContentAssistService extends ContentAssistService {
+	@Inject
+	private Provider<CancellableContentAssistContextFactory> contextFactoryProvider;
+
+	@Inject
+	private ExecutorService executorService;
+	
+	@Inject
+	private Provider<IdeContentProposalAcceptor> proposalAcceptorProvider;
+	
+	@Inject
+	private IdeContentProposalProvider proposalProvider;
+
+	@Inject
+	private OperationCanceledManager operationCanceledManager;
+	
+	@Override
+	public CompletionList createCompletionList(Document document, XtextResource resource, CompletionParams params,
+			CancelIndicator cancelIndicator) {
+		try {
+			CompletionList result = new CompletionList();
+			result.setIsIncomplete(true);
+			IdeContentProposalAcceptor acceptor = proposalAcceptorProvider.get();
+			int caretOffset = document.getOffSet(params.getPosition());
+			Position caretPosition = params.getPosition();
+			TextRegion position = new TextRegion(caretOffset, 0);
+			try {
+				createProposals(document.getContents(), position, caretOffset, resource, acceptor, cancelIndicator);
+			} catch (Throwable t) {
+				if (!operationCanceledManager.isOperationCanceledException(t)) {
+					throw t;
+				}
+			}
+			int idx = 0;
+			for (ContentAssistEntry it : acceptor.getEntries()) {
+				CompletionItem item = toCompletionItem(it, caretOffset, caretPosition, document);
+				item.setSortText(Strings.padStart(Integer.toString(idx), 5, '0'));
+				result.getItems().add(item);
+				idx++;
+			}
+			return result;
+		} catch (Throwable e) {
+			throw Exceptions.sneakyThrow(e);
+		}
+	}
+
+	protected void createProposals(String document, TextRegion selection, int caretOffset, XtextResource resource,
+			IIdeContentProposalAcceptor acceptor, CancelIndicator cancelIndicator) {
+		if (caretOffset > document.length()) {
+			return;
+		}
+		CancellableContentAssistContextFactory contextFactory = contextFactoryProvider.get();
+		contextFactory.setPool(executorService);
+		contextFactory.setCancelIndicator(cancelIndicator);
+		ContentAssistContext[] contexts = contextFactory.create(document, selection, caretOffset, resource);
+		proposalProvider.createProposals(Arrays.asList(contexts), acceptor);
+	}
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableContentAssistService.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableContentAssistService.java
@@ -25,6 +25,10 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 
 import com.google.common.base.Strings;
 
+/**
+ * A patch of Xtext's `CancellableContentAssistService` which makes a completion request cancellable.
+ * TODO: contribute to Xtext.
+ */
 public class CancellableContentAssistService extends ContentAssistService {
 	@Inject
 	private Provider<CancellableContentAssistContextFactory> contextFactoryProvider;
@@ -41,6 +45,8 @@ public class CancellableContentAssistService extends ContentAssistService {
 	@Inject
 	private OperationCanceledManager operationCanceledManager;
 	
+	// Patch of super.createCompletionList that passes the `cancelIndicator` on
+	// to the `createProposals` method.
 	@Override
 	public CompletionList createCompletionList(Document document, XtextResource resource, CompletionParams params,
 			CancelIndicator cancelIndicator) {
@@ -71,6 +77,7 @@ public class CancellableContentAssistService extends ContentAssistService {
 		}
 	}
 
+	// Patch of super.createProposals that accepts a `cancelIndicator`.
 	protected void createProposals(String document, TextRegion selection, int caretOffset, XtextResource resource,
 			IIdeContentProposalAcceptor acceptor, CancelIndicator cancelIndicator) {
 		if (caretOffset > document.length()) {

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableInternalRosettaParser.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableInternalRosettaParser.java
@@ -1,0 +1,44 @@
+package com.regnosys.rosetta.ide.contentassist.cancellable;
+
+import org.antlr.runtime.BitSet;
+import org.antlr.runtime.RecognizerSharedState;
+import org.antlr.runtime.TokenStream;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+
+import com.regnosys.rosetta.ide.contentassist.antlr.internal.InternalRosettaParser;
+
+/**
+ * A patch of the generated `InternalRosettaParser` which makes a completion request cancellable.
+ * TODO: contribute to Xtext.
+ */
+public class CancellableInternalRosettaParser extends InternalRosettaParser {
+	private final CancelIndicator cancelIndicator;
+	private final OperationCanceledManager operationCanceledManager;
+	
+	public CancellableInternalRosettaParser(TokenStream input, OperationCanceledManager operationCanceledManager, CancelIndicator cancelIndicator) {
+		super(input);
+		this.operationCanceledManager = operationCanceledManager;
+		this.cancelIndicator = cancelIndicator;
+	}
+	public CancellableInternalRosettaParser(TokenStream input, RecognizerSharedState state, OperationCanceledManager operationCanceledManager, CancelIndicator cancelIndicator) {
+        super(input, state);
+        this.operationCanceledManager = operationCanceledManager;
+        this.cancelIndicator = cancelIndicator;
+    }
+	
+	// Hook into the `before` method to check for cancellation.
+	@Override
+	public void before(EObject grammarElement) {
+		operationCanceledManager.checkCanceled(cancelIndicator);
+		super.before(grammarElement);
+	}
+	
+	// Hook into the `pushFollow` method to check for cancellation.
+	@Override
+	protected void pushFollow(BitSet fset) {
+		operationCanceledManager.checkCanceled(cancelIndicator);
+		super.pushFollow(fset);
+	}
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableRosettaParser.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/CancellableRosettaParser.java
@@ -1,0 +1,96 @@
+package com.regnosys.rosetta.ide.contentassist.cancellable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.antlr.runtime.TokenSource;
+import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.UnorderedGroup;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.ObservableXtextTokenStream;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.InfiniteRecursion;
+import org.eclipse.xtext.parser.antlr.IUnorderedGroupHelper;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+
+import com.google.common.collect.Lists;
+import com.regnosys.rosetta.ide.contentassist.antlr.RosettaParser;
+import com.regnosys.rosetta.services.RosettaGrammarAccess;
+
+/**
+ * A patch of the generated `RosettaParser` which makes a completion request cancellable.
+ * TODO: contribute to Xtext.
+ */
+public class CancellableRosettaParser extends RosettaParser implements ICancellableContentAssistParser {
+
+	@Inject
+	private RosettaGrammarAccess grammarAccess;
+	
+	@Inject
+	private OperationCanceledManager operationCanceledManager;
+
+	protected CancellableInternalRosettaParser createParser(CancelIndicator cancelIndicator) {
+		CancellableInternalRosettaParser result = new CancellableInternalRosettaParser(null, operationCanceledManager, cancelIndicator);
+		result.setGrammarAccess(grammarAccess);
+		return result;
+	}
+
+	// A patch of super.getFollowElements which uses an internal parser that supports
+	// cancellation.
+	@Override
+	public Collection<FollowElement> getFollowElements(String input, boolean strict, CancelIndicator cancelIndicator) {
+		TokenSource tokenSource = createTokenSource(input);
+		CancellableInternalRosettaParser parser = createParser(cancelIndicator);
+		parser.setStrict(strict);
+		ObservableXtextTokenStream tokens = new ObservableXtextTokenStream(tokenSource, parser);
+		tokens.setInitialHiddenTokens(getInitialHiddenTokens());
+		parser.setTokenStream(tokens);
+		IUnorderedGroupHelper helper = createUnorderedGroupHelper();
+		parser.setUnorderedGroupHelper(helper);
+		helper.initializeWith(parser);
+		tokens.setListener(parser);
+		try {
+			return Lists.newArrayList(getFollowElements(parser));
+		} catch (InfiniteRecursion infinite) {
+			return Lists.newArrayList(parser.getFollowElements());
+		}
+	}
+
+	// A patch of super.getFollowElements which uses an internal parser that supports
+	// cancellation.
+	@Override
+	public Collection<FollowElement> getFollowElements(FollowElement element, CancelIndicator cancelIndicator) {
+		if (element.getLookAhead() <= 1)
+			throw new IllegalArgumentException("lookahead may not be less than or equal to 1");
+		Collection<FollowElement> result = new ArrayList<>();
+		for (AbstractElement elementToParse : getElementsToParse(element)) {
+			elementToParse = unwrapSingleElementGroups(elementToParse);
+			String ruleName = getRuleName(elementToParse);
+			String[][] allRuleNames = getRequiredRuleNames(ruleName, element.getParamStack(), elementToParse);
+			for (String[] ruleNames : allRuleNames) {
+				for (int i = 0; i < ruleNames.length; i++) {
+					CancellableInternalRosettaParser parser = createParser(cancelIndicator);
+					parser.setUnorderedGroupHelper(createUnorderedGroupHelper());
+					parser.getUnorderedGroupHelper().initializeWith(parser);
+					ObservableXtextTokenStream tokens = setTokensFromFollowElement(parser, element);
+					tokens.setListener(parser);
+					parser.getGrammarElements().addAll(element.getTrace());
+					parser.getGrammarElements().add(elementToParse);
+					parser.getLocalTrace().addAll(element.getLocalTrace());
+					parser.getLocalTrace().add(elementToParse);
+					parser.getParamStack().addAll(element.getParamStack());
+					if (elementToParse instanceof UnorderedGroup && element.getGrammarElement() == elementToParse) {
+						UnorderedGroup group = (UnorderedGroup) elementToParse;
+						IUnorderedGroupHelper helper = getInitializedUnorderedGroupHelper(element, parser, group);
+						parser.setUnorderedGroupHelper(ignoreFirstEntrance(helper));
+					}
+					Collection<FollowElement> elements = getFollowElements(parser, elementToParse, ruleNames, i);
+					result.addAll(elements);
+				}
+			}
+		}
+		return result;
+	}
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/ICancellableContentAssistParser.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/ICancellableContentAssistParser.java
@@ -1,0 +1,13 @@
+package com.regnosys.rosetta.ide.contentassist.cancellable;
+
+import java.util.Collection;
+
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
+import org.eclipse.xtext.util.CancelIndicator;
+
+// TODO: contribute to Xtext
+public interface ICancellableContentAssistParser {
+	Collection<FollowElement> getFollowElements(String input, boolean strict, CancelIndicator cancelIndicator);
+
+	Collection<FollowElement> getFollowElements(FollowElement element, CancelIndicator cancelIndicator);
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/RosettaOperationCanceledManager.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/contentassist/cancellable/RosettaOperationCanceledManager.java
@@ -1,0 +1,23 @@
+package com.regnosys.rosetta.ide.contentassist.cancellable;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.xtext.service.OperationCanceledManager;
+
+// TODO: contribute to Xtext.
+public class RosettaOperationCanceledManager extends OperationCanceledManager {
+	@Override
+	protected RuntimeException getPlatformOperationCanceledException(Throwable t) {
+		RuntimeException result = super.getPlatformOperationCanceledException(t);
+		if (result != null) {
+			return result;
+		}
+		// Also inspect `InvocationTargetException`'s target exception.
+		if (t instanceof InvocationTargetException) {
+			return getPlatformOperationCanceledException(((InvocationTargetException)t).getTargetException());
+		} else if (t instanceof RuntimeException && t.getCause() instanceof InvocationTargetException) {
+			return getPlatformOperationCanceledException(((InvocationTargetException)t.getCause()).getTargetException());
+		}
+		return null;
+	}
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaRequestManager.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaRequestManager.java
@@ -1,0 +1,92 @@
+package com.regnosys.rosetta.ide.server;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.xtext.ide.server.concurrent.RequestManager;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.Functions.Function2;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * A request manager that will time out after a configurable amount of seconds.
+ * It can be configured through an environment variable.
+ */
+@Singleton
+public class RosettaRequestManager extends RequestManager {
+	public static String TIMEOUT_ENV_NAME = "ROSETTA_LANGUAGE_SERVER_REQUEST_TIMEOUT";
+		
+	private final Duration timeout;
+	private final ScheduledExecutorService scheduler =
+	        Executors.newScheduledThreadPool(
+	                1,
+	                new ThreadFactoryBuilder()
+	                        .setDaemon(true)
+	                        .setNameFormat("rosetta-language-server-request-timeout-%d")
+	                        .build());
+		
+	@Inject
+	public RosettaRequestManager(ExecutorService parallel, OperationCanceledManager operationCanceledManager) {
+		super(parallel, operationCanceledManager);
+		
+		String rawTimeout = System.getenv(TIMEOUT_ENV_NAME);
+		if (rawTimeout != null) {
+			this.timeout = Duration.ofSeconds(Long.parseLong(rawTimeout));
+		} else {
+			this.timeout = null;
+		}
+	}
+	
+	@Override
+	public <V> CompletableFuture<V> runRead(Function1<? super CancelIndicator, ? extends V> cancellable) {
+		return super.runRead((cancelIndicator) -> {		    
+		    try {
+		    	if (timeout == null) {
+		    		return cancellable.apply(cancelIndicator);
+		    	}
+				return CompletableFuture.supplyAsync(
+						() -> cancellable.apply(cancelIndicator),
+						scheduler
+					).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+			} catch (Exception ex) {
+				if (ex instanceof RuntimeException) {
+					throw (RuntimeException)ex;
+				}
+				throw new RuntimeException(ex);
+			}
+		});
+	}
+
+	@Override
+	public <U, V> CompletableFuture<V> runWrite(
+			Function0<? extends U> nonCancellable,
+			Function2<? super CancelIndicator, ? super U, ? extends V> cancellable) {
+		return super.runWrite(nonCancellable, (cancelIndicator, intermediate) -> {		    
+		    try {
+		    	if (timeout == null) {
+		    		return cancellable.apply(cancelIndicator, intermediate);
+		    	}
+				return CompletableFuture.supplyAsync(
+						() -> cancellable.apply(cancelIndicator, intermediate),
+						scheduler
+					).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+			} catch (Exception ex) {
+				if (ex instanceof RuntimeException) {
+					throw (RuntimeException)ex;
+				}
+				throw new RuntimeException(ex);
+			}
+		});
+	}
+}

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaServerModule.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaServerModule.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.xtext.ide.server.LanguageServerImpl;
 import org.eclipse.xtext.ide.server.ServerModule;
+import org.eclipse.xtext.ide.server.concurrent.RequestManager;
 import org.eclipse.xtext.service.AbstractGenericModule;
 
 import com.google.inject.util.Modules;
@@ -51,5 +52,9 @@ public class RosettaServerModule extends AbstractGenericModule {
 	 */
 	public Class<? extends LanguageServerImpl> bindLanguageServerImpl() {
 		return RosettaLanguageServerImpl.class;
+	}
+	
+	public Class<? extends RequestManager> bindRequestManager() {
+		return RosettaRequestManager.class;
 	}
 }

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/HandleParseErrorGracefullyTest.xtend
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/HandleParseErrorGracefullyTest.xtend
@@ -1,0 +1,30 @@
+package com.regnosys.rosetta.ide.server
+
+import com.regnosys.rosetta.ide.tests.AbstractRosettaLanguageServerTest
+import org.junit.jupiter.api.Test
+import org.eclipse.xtext.testing.TextDocumentConfiguration
+import static org.junit.jupiter.api.Assertions.*
+
+class HandleParseErrorGracefullyTest extends AbstractRosettaLanguageServerTest {
+	@Test
+	def void test() {
+		val uri = initializeContext(new TextDocumentConfiguration => [
+			it.filePath = 'MyModel.' + fileExtension
+			it.model = '''
+			namespace "test"
+			version "test"
+			
+			func Foo:
+				output: result int (0..1)
+				set result:
+					if False then 42
+					«FOR i: 0..1000»
+					else if False then 42
+					«ENDFOR»
+			'''
+		]).uri
+		val issues = diagnostics.get(uri)
+		assertEquals(1, issues.size)
+		assertEquals("An unexpected parse error occured.", issues.head.message)
+	}
+}

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/HandleParseErrorGracefullyTest.xtend
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/HandleParseErrorGracefullyTest.xtend
@@ -7,9 +7,11 @@ import static org.junit.jupiter.api.Assertions.*
 
 class HandleParseErrorGracefullyTest extends AbstractRosettaLanguageServerTest {
 	@Test
-	def void test() {
+	def void testStackoverflowResults() {
 		val uri = initializeContext(new TextDocumentConfiguration => [
 			it.filePath = 'MyModel.' + fileExtension
+			// Create a model containing 1000 `else if`'s, which should cause
+			// a stack overflow during parsing.
 			it.model = '''
 			namespace "test"
 			version "test"

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/tests/AbstractRosettaLanguageServerTest.xtend
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/tests/AbstractRosettaLanguageServerTest.xtend
@@ -20,8 +20,6 @@ import com.regnosys.rosetta.ide.util.RangeUtils
 import java.util.stream.Collectors
 import org.junit.jupiter.api.Assertions
 import com.regnosys.rosetta.builtin.RosettaBuiltinsService
-import org.eclipse.xtext.util.Modules2
-import org.eclipse.xtext.ide.server.concurrent.RequestManager
 import com.regnosys.rosetta.ide.server.RosettaServerModule
 import com.google.inject.Module
 import org.eclipse.lsp4j.DiagnosticSeverity
@@ -40,9 +38,7 @@ abstract class AbstractRosettaLanguageServerTest extends AbstractLanguageServerT
 	
 	protected override Module getServerModule() {
 		RosettaStandaloneSetup.doSetup
-		return Modules2.mixin(RosettaServerModule.create) [
-			// bind(RequestManager).to(DirectRequestManager)
-		]
+		return RosettaServerModule.create
 	}
 	
 	protected def void assertNoIssues() {

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/tests/AbstractRosettaLanguageServerTest.xtend
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/tests/AbstractRosettaLanguageServerTest.xtend
@@ -41,7 +41,7 @@ abstract class AbstractRosettaLanguageServerTest extends AbstractLanguageServerT
 	protected override Module getServerModule() {
 		RosettaStandaloneSetup.doSetup
 		return Modules2.mixin(RosettaServerModule.create) [
-			bind(RequestManager).to(DirectRequestManager)
+			// bind(RequestManager).to(DirectRequestManager)
 		]
 	}
 	

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/RosettaRuntimeModule.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/RosettaRuntimeModule.xtend
@@ -15,7 +15,6 @@ import com.regnosys.rosetta.resource.RosettaResourceDescriptionStrategy
 import com.regnosys.rosetta.scoping.RosettaQualifiedNameProvider
 import org.eclipse.xtext.generator.IOutputConfigurationProvider
 import org.eclipse.xtext.naming.IQualifiedNameProvider
-import org.eclipse.xtext.resource.DerivedStateAwareResource
 import org.eclipse.xtext.resource.IDerivedStateComputer
 import org.eclipse.xtext.resource.IFragmentProvider
 import org.eclipse.xtext.resource.IResourceDescription
@@ -38,6 +37,7 @@ import javax.inject.Provider
 import com.regnosys.rosetta.generator.java.util.RecordJavaUtil
 import com.regnosys.rosetta.serialization.RosettaTransientValueService
 import org.eclipse.xtext.parsetree.reconstr.ITransientValueService
+import com.regnosys.rosetta.resource.RosettaResource
 
 /* Use this class to register components to be used at runtime / without the Equinox extension registry.*/
 class RosettaRuntimeModule extends AbstractRosettaRuntimeModule {
@@ -55,11 +55,11 @@ class RosettaRuntimeModule extends AbstractRosettaRuntimeModule {
 	}
 	
 	override Class<? extends IQualifiedNameProvider> bindIQualifiedNameProvider() {
-		return RosettaQualifiedNameProvider
+		RosettaQualifiedNameProvider
 	}
 	
 	def Class<? extends IOutputConfigurationProvider> bindIOutputConfigurationProvider() {
-		return RosettaOutputConfigurationProvider
+		RosettaOutputConfigurationProvider
 	}
 	
 	def Class<? extends IResourceDescription.Manager> bindIResourceDescriptionManager() {
@@ -95,7 +95,7 @@ class RosettaRuntimeModule extends AbstractRosettaRuntimeModule {
     }
 	
 	override Class<? extends XtextResource> bindXtextResource() {
-		DerivedStateAwareResource
+		RosettaResource
 	}
 	def Class<? extends IDerivedStateComputer> bindIDerivedStateComputer() {
 		RosettaDerivedStateComputer

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/resource/RosettaResource.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/resource/RosettaResource.java
@@ -1,0 +1,60 @@
+package com.regnosys.rosetta.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.eclipse.xtext.resource.DerivedStateAwareResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A resource that will handle unexpected exceptions (e.g., a StackOverflowException)
+ * during parsing in the following way:
+ * - Log the exception.
+ * - Raise a syntax validation diagnostic indicating an unexpected error occurred.
+ * - Do not rethrow the underlying exception. Processing of the resource can continue
+ *   as if a syntax error occurred. The resource will not contain any `EObject`, and
+ *   `parseResult` will be `null`.
+ */
+public class RosettaResource extends DerivedStateAwareResource {
+	private static Logger LOGGER = LoggerFactory.getLogger(RosettaResource.class);
+	
+	public static final String UNEXPECTED_ERROR_MESSAGE = "An unexpected parse error occured.";
+	
+	@Override
+	protected void doLoad(InputStream inputStream, Map<?, ?> options) throws IOException {
+		try {
+			super.doLoad(inputStream, options);
+		} catch(Exception ex) {
+			if (this.getParseResult() == null) {
+				LOGGER.error("Unexpected error during parsing of " + getURI() + ".", ex);
+				clearCache();
+				clearErrorsAndWarnings();
+				getErrors().add(new Diagnostic() {
+					@Override
+					public String getMessage() {
+						return UNEXPECTED_ERROR_MESSAGE;
+					}
+
+					@Override
+					public String getLocation() {
+						return RosettaResource.this.getURI().toString();
+					}
+
+					@Override
+					public int getLine() {
+						return 0;
+					}
+
+					@Override
+					public int getColumn() {
+						return 0;
+					}
+				});
+			} else {
+				throw ex;
+			}
+		}
+	}
+}

--- a/rosetta-tools/.classpath
+++ b/rosetta-tools/.classpath
@@ -31,6 +31,13 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/xtend-gen">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/rosetta-tools/.classpath
+++ b/rosetta-tools/.classpath
@@ -31,13 +31,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/xtend-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>


### PR DESCRIPTION
ISSUE-861: Long if-then-else statement crashes BSP due to a null pointer exception in the ANTLR parser

Improvements:
- Unexpected errors during parsing (e.g., a `StackOverflowException`) are now handled gracefully (catch, log, return diagnostic to the user)
- Completion requests to the language server are now cancellable, which means they don't block subsequent requests if they run for a long time.
- Long requests to the language server will now time out after a configurable amount of seconds (configurable through an environment variable)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
