### PR TITLE
Story-653 - Rewording Error messages to be more efficient when looking at remediation.

### DIFF
--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -281,13 +281,13 @@ public class ExpressionOperators {
 		List<String> failures = new ArrayList<>();
 		if (value.length() < minLength) {
 		//	failures.add("Expected a minimum of " + minLength + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
-			failures.add("Field '" + msgPrefix + " must have a value with minimum length of '" + minLength + " characters but value '" + value + "' is length of " + value.length() + " characters.");
+			failures.add("Field '" + msgPrefix + "' must have a value with minimum length of " + minLength + " characters but value '" + value + "' is length of " + value.length() + " characters.");
 
 		}
 		if (maxLength.isPresent()) {
 			int m = maxLength.get();
 			if (value.length() > m) {
-				failures.add("Field '" + msgPrefix + " must have a value with maximum length of '" + m + " characters but value '" + value + "' is length of " + value.length() + " characters.");
+				failures.add("Field '" + msgPrefix + "' must have a value with maximum length of " + m + " characters but value '" + value + "' is length of " + value.length() + " characters.");
 
 				//failures.add("Expected a maximum of " + m + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
 			}
@@ -297,7 +297,7 @@ public class ExpressionOperators {
 			Matcher match = p.matcher(value);
 			if (!match.matches()) {
 				//failures.add("'" + value + "' does not match the pattern /" + p.toString() + "/ of '" + msgPrefix + "'.");
-				failures.add("Field '" + msgPrefix + "' with value "+ value + "' does not match the pattern / " + p.toString() + " /.");
+				failures.add("Field '" + msgPrefix + "' with value '"+ value + "' does not match the pattern /" + p.toString() + "/.");
 
 			}
 		}

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -46,7 +46,11 @@ public class ExpressionOperators {
 		if (o.resultCount()>0) {
 			return ComparisonResult.success();
 		}
-		return ComparisonResult.failure(o.getErrorPaths() + " does not exist");
+		String failuremessage = null;
+		if (o.getErrorPaths()!= null){
+			failuremessage = o.getErrorPaths() + " does not exist";
+		}
+		return ComparisonResult.failure(failuremessage);
 	}
 	
 	// singleExists

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -259,8 +259,14 @@ public class ExpressionOperators {
 	
 	public static ComparisonResult checkCardinality(String msgPrefix, int actual, int min, int max) {
 		if (actual < min) {
-			return ComparisonResult
-					.failure("Minimum of " + min + " '" + msgPrefix + "' is expected but found " + actual + ".");
+			if(actual == 0){
+				return ComparisonResult
+						.failure("'" + msgPrefix + "' is a required field but does not exist.");
+			}
+			else {
+				return ComparisonResult
+						.failure("Minimum of " + min + " '" + msgPrefix + "' is expected but found " + actual + ".");
+			}
 		} else if (max > 0 && actual > max) {
 			return ComparisonResult
 					.failure("Maximum of " + max + " '" + msgPrefix + "' are expected but found " + actual + ".");
@@ -274,19 +280,25 @@ public class ExpressionOperators {
 		}
 		List<String> failures = new ArrayList<>();
 		if (value.length() < minLength) {
-			failures.add("Expected a minimum of " + minLength + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
+		//	failures.add("Expected a minimum of " + minLength + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
+			failures.add("Field '" + msgPrefix + " must have a value with minimum length of '" + minLength + " characters but value '" + value + "' is length of " + value.length() + " characters.");
+
 		}
 		if (maxLength.isPresent()) {
 			int m = maxLength.get();
 			if (value.length() > m) {
-				failures.add("Expected a maximum of " + m + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
+				failures.add("Field '" + msgPrefix + " must have a value with maximum length of '" + m + " characters but value '" + value + "' is length of " + value.length() + " characters.");
+
+				//failures.add("Expected a maximum of " + m + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
 			}
 		}
 		if (pattern.isPresent()) {
 			Pattern p = pattern.get();
 			Matcher match = p.matcher(value);
 			if (!match.matches()) {
-				failures.add("'" + value + "' does not match the pattern /" + p.toString() + "/ of '" + msgPrefix + "'.");
+				//failures.add("'" + value + "' does not match the pattern /" + p.toString() + "/ of '" + msgPrefix + "'.");
+				failures.add("Field '" + msgPrefix + "' with value "+ value + "' does not match the pattern / " + p.toString() + " /.");
+
 			}
 		}
 		if (failures.isEmpty()) {

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -284,13 +284,13 @@ public class ExpressionOperators {
 		}
 		List<String> failures = new ArrayList<>();
 		if (value.length() < minLength) {
-			failures.add("Field '" + msgPrefix + "' must have a value with minimum length of " + minLength + " characters but value '" + value + "' is length of " + value.length() + " characters.");
+			failures.add("Field '" + msgPrefix + "' requires a value with minimum length of " + minLength + " characters but value '" + value + "' has length of " + value.length() + " characters.");
 
 		}
 		if (maxLength.isPresent()) {
 			int m = maxLength.get();
 			if (value.length() > m) {
-				failures.add("Field '" + msgPrefix + "' must have a value with maximum length of " + m + " characters but value '" + value + "' is length of " + value.length() + " characters.");
+				failures.add("Field '" + msgPrefix + "' must have a value with maximum length of " + m + " characters but value '" + value + "' has length of " + value.length() + " characters.");
 			}
 		}
 		if (pattern.isPresent()) {

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -284,7 +284,6 @@ public class ExpressionOperators {
 		}
 		List<String> failures = new ArrayList<>();
 		if (value.length() < minLength) {
-		//	failures.add("Expected a minimum of " + minLength + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
 			failures.add("Field '" + msgPrefix + "' must have a value with minimum length of " + minLength + " characters but value '" + value + "' is length of " + value.length() + " characters.");
 
 		}
@@ -292,15 +291,12 @@ public class ExpressionOperators {
 			int m = maxLength.get();
 			if (value.length() > m) {
 				failures.add("Field '" + msgPrefix + "' must have a value with maximum length of " + m + " characters but value '" + value + "' is length of " + value.length() + " characters.");
-
-				//failures.add("Expected a maximum of " + m + " characters for '" + msgPrefix + "', but found '" + value + "' (" + value.length() + " characters).");
 			}
 		}
 		if (pattern.isPresent()) {
 			Pattern p = pattern.get();
 			Matcher match = p.matcher(value);
 			if (!match.matches()) {
-				//failures.add("'" + value + "' does not match the pattern /" + p.toString() + "/ of '" + msgPrefix + "'.");
 				failures.add("Field '" + msgPrefix + "' with value '"+ value + "' does not match the pattern /" + p.toString() + "/.");
 
 			}

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -46,11 +46,11 @@ public class ExpressionOperators {
 		if (o.resultCount()>0) {
 			return ComparisonResult.success();
 		}
-		String failuremessage = null;
-		if (o.getErrorPaths()!= null){
-			failuremessage = o.getErrorPaths() + " does not exist";
+		String failureMessage = null;
+		if (o.getErrorPaths()!= null && !o.getErrorPaths().isEmpty()){
+			failureMessage = o.getErrorPaths() + " does not exist";
 		}
-		return ComparisonResult.failure(failuremessage);
+		return ComparisonResult.failure(failureMessage);
 	}
 	
 	// singleExists

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorTest.xtend
@@ -220,7 +220,7 @@ class ModelMetaGeneratorTest {
 		))
 		val res1 = validator.validate(null, invalidFoo1)
 		assertThat(res1.success, is(false))
-		assertEquals("Maximum of 2 'a' are expected but found 3.; Minimum of 1 'b' is expected but found 0.; Minimum of 1 'c' is expected but found 0.",
+		assertEquals("Maximum of 2 'a' are expected but found 3.; 'b' is a required field but does not exist.; 'c' is a required field but does not exist.",
 			res1.failureReason.get
 		)
 		assertThat(res1.validationType, is(ValidationType.CARDINALITY))
@@ -236,7 +236,7 @@ class ModelMetaGeneratorTest {
 		assertThat(validator.validate(null, invalidFoo2).success, is(true))
 		val res2 = typeFormatValidator.validate(null, invalidFoo2)
 		assertThat(res2.success, is(false))
-		assertEquals("Expected a number greater than or equal to -1 for 'd', but found -1.1.; Expected a maximum of 5 characters for 'f', but found 'aaaaaa' (6 characters). - Expected a maximum of 5 characters for 'f', but found 'ccccccc' (7 characters).",
+		assertEquals("Expected a number greater than or equal to -1 for 'd', but found -1.1.; Field 'f' must have a value with maximum length of 5 characters but value 'aaaaaa' is length of 6 characters. - Field 'f' must have a value with maximum length of 5 characters but value 'ccccccc' is length of 7 characters.",
 			res2.failureReason.get
 		)
 		assertThat(res2.validationType, is(ValidationType.TYPE_FORMAT))
@@ -264,8 +264,8 @@ class ModelMetaGeneratorTest {
 		))
 		val resA1 = aTypeFormatValidator.validate(null, invalidA1)
 		assertThat(resA1.success, is(false))
-		assertEquals("Expected a minimum of 3 characters for 'a', but found 'AZ' (2 characters). - Expected a minimum of 3 characters for 'a', but found 'AA' (2 characters). 'AA' does not match the pattern /A.*Z/ of 'a'.; Expected a maximum of 5 characters for 'b', but found 'AAAAAA' (6 characters).",
-			resA1.failureReason.get
+        assertEquals("Field 'a' must have a value with minimum length of 3 characters but value 'AZ' is length of 2 characters. - Field 'a' must have a value with minimum length of 3 characters but value 'AA' is length of 2 characters. Field 'a' with value 'AA' does not match the pattern /A.*Z/.; Field 'b' must have a value with maximum length of 5 characters but value 'AAAAAA' is length of 6 characters.",
+            resA1.failureReason.get
 		)
 		
 		val bMeta = RosettaMetaData.cast(classes.get(rootPackage.meta + '.BMeta').declaredConstructor.newInstance)

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorTest.xtend
@@ -236,7 +236,7 @@ class ModelMetaGeneratorTest {
 		assertThat(validator.validate(null, invalidFoo2).success, is(true))
 		val res2 = typeFormatValidator.validate(null, invalidFoo2)
 		assertThat(res2.success, is(false))
-		assertEquals("Expected a number greater than or equal to -1 for 'd', but found -1.1.; Field 'f' must have a value with maximum length of 5 characters but value 'aaaaaa' is length of 6 characters. - Field 'f' must have a value with maximum length of 5 characters but value 'ccccccc' is length of 7 characters.",
+		assertEquals("Expected a number greater than or equal to -1 for 'd', but found -1.1.; Field 'f' must have a value with maximum length of 5 characters but value 'aaaaaa' has length of 6 characters. - Field 'f' must have a value with maximum length of 5 characters but value 'ccccccc' has length of 7 characters.",
 			res2.failureReason.get
 		)
 		assertThat(res2.validationType, is(ValidationType.TYPE_FORMAT))
@@ -264,7 +264,7 @@ class ModelMetaGeneratorTest {
 		))
 		val resA1 = aTypeFormatValidator.validate(null, invalidA1)
 		assertThat(resA1.success, is(false))
-        assertEquals("Field 'a' must have a value with minimum length of 3 characters but value 'AZ' is length of 2 characters. - Field 'a' must have a value with minimum length of 3 characters but value 'AA' is length of 2 characters. Field 'a' with value 'AA' does not match the pattern /A.*Z/.; Field 'b' must have a value with maximum length of 5 characters but value 'AAAAAA' is length of 6 characters.",
+        assertEquals("Field 'a' requires a value with minimum length of 3 characters but value 'AZ' has length of 2 characters. - Field 'a' requires a value with minimum length of 3 characters but value 'AA' has length of 2 characters. Field 'a' with value 'AA' does not match the pattern /A.*Z/.; Field 'b' must have a value with maximum length of 5 characters but value 'AAAAAA' has length of 6 characters.",
             resA1.failureReason.get
 		)
 		


### PR DESCRIPTION
Rewording Error message displayed on diagnostic panels to be more efficient when looking at remediation.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)