### PR TITLE
Story 658 - sending Condition name in error message for all DataRule validationType

### DIFF
--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/condition/ConditionGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/condition/ConditionGenerator.xtend
@@ -100,8 +100,8 @@ class ConditionGenerator {
 						}
 						
 						String «defaultClassFailureMessageId» = «defaultClassResultId».getError();
-						if («defaultClassFailureMessageId» == null) {
-							«defaultClassFailureMessageId» = "Condition " + NAME + " failed.";
+						if («defaultClassFailureMessageId» == null || «defaultClassFailureMessageId».contains("Null") || «defaultClassFailureMessageId» == "") {
+							«defaultClassFailureMessageId» = "Condition has failed.";
 						}
 						return «ValidationResult».failure(NAME, «ValidationType».DATA_RULE, "«rosettaClass.name»", «defaultClassPathId», DEFINITION, «defaultClassFailureMessageId»);
 					}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/condition/ConditionGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/condition/ConditionGenerator.xtend
@@ -101,7 +101,7 @@ class ConditionGenerator {
 						
 						String «defaultClassFailureMessageId» = «defaultClassResultId».getError();
 						if («defaultClassFailureMessageId» == null || «defaultClassFailureMessageId».contains("Null") || «defaultClassFailureMessageId» == "") {
-							«defaultClassFailureMessageId» = "Condition has failed.";
+							«defaultClassFailureMessageId» = "Condition " + NAME + " failed.";
 						}
 						return «ValidationResult».failure(NAME, «ValidationType».DATA_RULE, "«rosettaClass.name»", «defaultClassPathId», DEFINITION, «defaultClassFailureMessageId»);
 					}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/condition/ConditionGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/condition/ConditionGenerator.xtend
@@ -101,7 +101,7 @@ class ConditionGenerator {
 						
 						String «defaultClassFailureMessageId» = «defaultClassResultId».getError();
 						if («defaultClassFailureMessageId» == null || «defaultClassFailureMessageId».contains("Null") || «defaultClassFailureMessageId» == "") {
-							«defaultClassFailureMessageId» = "Condition " + NAME + " failed.";
+							«defaultClassFailureMessageId» = "Condition has failed.";
 						}
 						return «ValidationResult».failure(NAME, «ValidationType».DATA_RULE, "«rosettaClass.name»", «defaultClassPathId», DEFINITION, «defaultClassFailureMessageId»);
 					}

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -46,11 +46,7 @@ public class ExpressionOperators {
 		if (o.resultCount()>0) {
 			return ComparisonResult.success();
 		}
-		String failureMessage = null;
-		if (o.getErrorPaths()!= null && !o.getErrorPaths().isEmpty() && !o.getErrorPaths().toString().contains("Null")){
-			failureMessage = o.getErrorPaths() + " does not exist";
-		}
-		return ComparisonResult.failure(failureMessage);
+		return ComparisonResult.failure(o.getErrorPaths() + " does not exist");
 	}
 	
 	// singleExists

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/expression/ExpressionOperators.java
@@ -47,7 +47,7 @@ public class ExpressionOperators {
 			return ComparisonResult.success();
 		}
 		String failureMessage = null;
-		if (o.getErrorPaths()!= null && !o.getErrorPaths().isEmpty()){
+		if (o.getErrorPaths()!= null && !o.getErrorPaths().isEmpty() && !o.getErrorPaths().toString().contains("Null")){
 			failureMessage = o.getErrorPaths() + " does not exist";
 		}
 		return ComparisonResult.failure(failureMessage);

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
@@ -83,7 +83,7 @@ public interface ValidationResult<T> {
 		
 		@Override
 		public Optional<String> getFailureReason() {
-			if (failureReason.isPresent() && ValidationType.DATA_RULE.equals(validationType)) {
+			if (failureReason.isPresent() && modelObjectName.endsWith("Report") && ValidationType.DATA_RULE.equals(validationType)) {
 				return getUpdatedFailureReason();
 			}
 			return failureReason;

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
@@ -83,7 +83,7 @@ public interface ValidationResult<T> {
 		
 		@Override
 		public Optional<String> getFailureReason() {
-			if (failureReason.isPresent() && modelObjectName.endsWith("Report") && ValidationType.DATA_RULE.equals(validationType)) {
+			if (failureReason.isPresent() && ValidationType.DATA_RULE.equals(validationType)) {
 				return getUpdatedFailureReason();
 			}
 			return failureReason;

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
@@ -83,7 +83,7 @@ public interface ValidationResult<T> {
 		
 		@Override
 		public Optional<String> getFailureReason() {
-			if (failureReason.isPresent() && modelObjectName.endsWith("Report")) {
+			if (failureReason.isPresent() && modelObjectName.endsWith("Report") && ValidationType.DATA_RULE.equals(validationType)) {
 				return getUpdatedFailureReason();
 			}
 			return failureReason;

--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/validation/ValidationResult.java
@@ -83,7 +83,7 @@ public interface ValidationResult<T> {
 		
 		@Override
 		public Optional<String> getFailureReason() {
-			if (failureReason.isPresent() && modelObjectName.endsWith("Report") && failureReason.get().contains(modelObjectName)) {
+			if (failureReason.isPresent() && modelObjectName.endsWith("Report")) {
 				return getUpdatedFailureReason();
 			}
 			return failureReason;
@@ -113,6 +113,7 @@ public interface ValidationResult<T> {
 			failReason = failReason.replaceAll(modelObjectName, "");
 			failReason = failReason.replaceAll("->get", " ");
 			failReason = failReason.replaceAll("[^\\w-]+", " ");
+			failReason = failReason.replaceAll("^\\s+", "");
 
 			return Optional.of(conditionName + ":- " + failReason);
 		}

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/condition/DataRuleGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/condition/DataRuleGeneratorTest.xtend
@@ -82,7 +82,7 @@ class DataRuleGeneratorTest {
 							
 							String failureMessage = result.getError();
 							if (failureMessage == null) {
-								failureMessage = "Condition " + NAME + " failed.";
+								failureMessage = "Condition has failed.";
 							}
 							return ValidationResult.failure(NAME, ValidationType.DATA_RULE, "Foo", path, DEFINITION, failureMessage);
 						}
@@ -199,7 +199,7 @@ class DataRuleGeneratorTest {
 							
 							String failureMessage = result.getError();
 							if (failureMessage == null) {
-								failureMessage = "Condition " + NAME + " failed.";
+								failureMessage = "Condition has failed.";
 							}
 							return ValidationResult.failure(NAME, ValidationType.DATA_RULE, "Foo", path, DEFINITION, failureMessage);
 						}

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/condition/DataRuleGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/condition/DataRuleGeneratorTest.xtend
@@ -81,7 +81,7 @@ class DataRuleGeneratorTest {
 							}
 							
 							String failureMessage = result.getError();
-							if (failureMessage == null) {
+							if (failureMessage == null || failureMessage.contains("Null") || failureMessage == "") {
 								failureMessage = "Condition has failed.";
 							}
 							return ValidationResult.failure(NAME, ValidationType.DATA_RULE, "Foo", path, DEFINITION, failureMessage);
@@ -198,7 +198,7 @@ class DataRuleGeneratorTest {
 							}
 							
 							String failureMessage = result.getError();
-							if (failureMessage == null) {
+							if (failureMessage == null || failureMessage.contains("Null") || failureMessage == "") {
 								failureMessage = "Condition has failed.";
 							}
 							return ValidationResult.failure(NAME, ValidationType.DATA_RULE, "Foo", path, DEFINITION, failureMessage);

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
@@ -4511,7 +4511,7 @@ class FunctionGeneratorTest {
 							
 							String failureMessage = result.getError();
 							if (failureMessage == null) {
-								failureMessage = "Condition " + NAME + " failed.";
+								failureMessage = "Condition has failed.";
 							}
 							return ValidationResult.failure(NAME, ValidationType.DATA_RULE, "Foo", path, DEFINITION, failureMessage);
 						}

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
@@ -4510,7 +4510,7 @@ class FunctionGeneratorTest {
 							}
 							
 							String failureMessage = result.getError();
-							if (failureMessage == null) {
+							if (failureMessage == null || failureMessage.contains("Null") || failureMessage == "") {
 								failureMessage = "Condition has failed.";
 							}
 							return ValidationResult.failure(NAME, ValidationType.DATA_RULE, "Foo", path, DEFINITION, failureMessage);


### PR DESCRIPTION
Updated the Condition to be refactor the error message to include condition name for all Data Rule validation. 
checks for Null and contains text null to just send Condition has failed for error message which is comparing against null value and will display weird error message which are difficult to be interpreted by Users

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
