### PR TITLE
Story 674 - task 3660 Fix RequestManager memory leak

### DIFF
--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaRequestManager.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaRequestManager.java
@@ -1,15 +1,7 @@
 package com.regnosys.rosetta.ide.server;
 
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.eclipse.xtext.ide.server.concurrent.AbstractRequest;
 import org.eclipse.xtext.ide.server.concurrent.RequestManager;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
@@ -17,7 +9,11 @@ import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Functions.Function2;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.*;
 
 /**
  * A request manager that will time out after a configurable amount of seconds.
@@ -35,7 +31,9 @@ public class RosettaRequestManager extends RequestManager {
 	                        .setDaemon(true)
 	                        .setNameFormat("rosetta-language-server-request-timeout-%d")
 	                        .build());
-		
+
+	private List<AbstractRequest<?>> removableRequestList = new CopyOnWriteArrayList<>();
+
 	@Inject
 	public RosettaRequestManager(ExecutorService parallel, OperationCanceledManager operationCanceledManager) {
 		super(parallel, operationCanceledManager);
@@ -46,6 +44,33 @@ public class RosettaRequestManager extends RequestManager {
 		} else {
 			this.timeout = null;
 		}
+	}
+
+	@Override
+	protected <V> CompletableFuture<V> submit(AbstractRequest<V> request) {
+		addRequest(request);
+		submitRequest(request);
+		return request.get().whenComplete((result, error) -> {
+			removableRequestList.remove(request);
+		});
+	}
+
+	@Override
+	protected void addRequest(AbstractRequest<?> request) {
+		removableRequestList.add(request);
+	}
+
+	@Override
+	protected CompletableFuture<Void> cancel() {
+		List<AbstractRequest<?>> localRequests = removableRequestList;
+		removableRequestList = new CopyOnWriteArrayList<>();
+		CompletableFuture<?>[] cfs = new CompletableFuture<?>[localRequests.size()];
+		for (int i = 0, max = localRequests.size(); i < max; i++) {
+			AbstractRequest<?> request = localRequests.get(i);
+			request.cancel();
+			cfs[i] = request.get();
+		}
+		return CompletableFuture.allOf(cfs);
 	}
 	
 	@Override

--- a/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaRequestManager.java
+++ b/rosetta-ide/src/main/java/com/regnosys/rosetta/ide/server/RosettaRequestManager.java
@@ -1,6 +1,5 @@
 package com.regnosys.rosetta.ide.server;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.eclipse.xtext.ide.server.concurrent.AbstractRequest;
 import org.eclipse.xtext.ide.server.concurrent.RequestManager;
@@ -37,7 +36,7 @@ public class RosettaRequestManager extends RequestManager {
 	 * The code that uses this list fixes a memory leak in the RequestManager and should be contributed
 	 * back to the Xtext project then removed from here
 	 */
-	@VisibleForTesting
+	/* @ProtectedForTesting */
 	protected List<AbstractRequest<?>> removableRequestList = new CopyOnWriteArrayList<>();
 
 	@Inject

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/RosettaRequestManagerTest.java
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/RosettaRequestManagerTest.java
@@ -24,28 +24,19 @@ class RosettaRequestManagerTest {
 
     @Test
     public void testReadRequestsAreClearedFromRequestList() throws ExecutionException, InterruptedException, TimeoutException {
-        CompletableFuture<Void> voidCompletableFuture = new CompletableFuture<>();
 
-        rosettaRequestManager.runRead((cancelIndicator) -> {
-            voidCompletableFuture.complete(null);
-            return null;
-        });
+        CompletableFuture<Object> completableFuture = rosettaRequestManager.runRead((cancelIndicator) -> null);
 
-        voidCompletableFuture.get(300, TimeUnit.MILLISECONDS);
+       completableFuture.get(300, TimeUnit.MILLISECONDS);
 
         assertThat(rosettaRequestManager.removableRequestList.size(), equalTo(0));
     }
 
     @Test
     public void testWriteRequestsAreClearedFromRequestList() throws ExecutionException, InterruptedException, TimeoutException {
-        CompletableFuture<Void> voidCompletableFuture = new CompletableFuture<>();
+        CompletableFuture<Object> completableFuture = rosettaRequestManager.runWrite(() -> null, (a, b) -> null);
 
-        rosettaRequestManager.runWrite(() -> null, (a, b) -> {
-            voidCompletableFuture.complete(null);
-            return null;
-        });
-
-        voidCompletableFuture.get(300, TimeUnit.MILLISECONDS);
+        completableFuture.get(300, TimeUnit.MILLISECONDS);
 
         assertThat(rosettaRequestManager.removableRequestList.size(), equalTo(0));
     }

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/RosettaRequestManagerTest.java
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/RosettaRequestManagerTest.java
@@ -23,7 +23,7 @@ class RosettaRequestManagerTest {
     RosettaRequestManager rosettaRequestManager;
 
     @Test
-    public void testRequestListIsClearedDown() throws ExecutionException, InterruptedException, TimeoutException {
+    public void testReadRequestsAreClearedFromRequestList() throws ExecutionException, InterruptedException, TimeoutException {
         CompletableFuture<Void> voidCompletableFuture = new CompletableFuture<>();
 
         rosettaRequestManager.runRead((cancelIndicator) -> {
@@ -36,6 +36,18 @@ class RosettaRequestManagerTest {
         assertThat(rosettaRequestManager.removableRequestList.size(), equalTo(0));
     }
 
+    @Test
+    public void testWriteRequestsAreClearedFromRequestList() throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<Void> voidCompletableFuture = new CompletableFuture<>();
 
+        rosettaRequestManager.runWrite(() -> null, (a, b) -> {
+            voidCompletableFuture.complete(null);
+            return null;
+        });
+
+        voidCompletableFuture.get(300, TimeUnit.MILLISECONDS);
+
+        assertThat(rosettaRequestManager.removableRequestList.size(), equalTo(0));
+    }
 
 }

--- a/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/RosettaRequestManagerTest.java
+++ b/rosetta-ide/src/test/java/com/regnosys/rosetta/ide/server/RosettaRequestManagerTest.java
@@ -1,0 +1,41 @@
+package com.regnosys.rosetta.ide.server;
+
+import com.regnosys.rosetta.ide.tests.RosettaIdeInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaIdeInjectorProvider.class)
+class RosettaRequestManagerTest {
+
+    @Inject
+    RosettaRequestManager rosettaRequestManager;
+
+    @Test
+    public void testRequestListIsClearedDown() throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<Void> voidCompletableFuture = new CompletableFuture<>();
+
+        rosettaRequestManager.runRead((cancelIndicator) -> {
+            voidCompletableFuture.complete(null);
+            return null;
+        });
+
+        voidCompletableFuture.get(300, TimeUnit.MILLISECONDS);
+
+        assertThat(rosettaRequestManager.removableRequestList.size(), equalTo(0));
+    }
+
+
+
+}


### PR DESCRIPTION
This change fixes a leak in the XText RequestManager where the request store grows continuously when on read request are sent

## Type of change

- Bug fix (non-breaking change which fixes an issue)

