### PR TITLE
story 1514 task-7601: throw exception if config cannot be parsed

### DIFF
--- a/rune-lang/src/main/java/com/regnosys/rosetta/config/file/FileBasedRosettaConfigurationProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/config/file/FileBasedRosettaConfigurationProvider.java
@@ -59,8 +59,7 @@ public class FileBasedRosettaConfigurationProvider implements Provider<RosettaCo
 			LOGGER.debug("No configuration file was found. Falling back to the default configuration.");
 			return null;
 		} catch (IOException e) {
-			LOGGER.error("Could not read Rosetta configuration.", e);
-			return null;
+      throw new FileBasedRosettaConfigurationRuntimeException("Could not read Rosetta configuration.", e);
 		}
 	}
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/config/file/FileBasedRosettaConfigurationRuntimeException.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/config/file/FileBasedRosettaConfigurationRuntimeException.java
@@ -1,0 +1,7 @@
+package com.regnosys.rosetta.config.file;
+
+public class FileBasedRosettaConfigurationRuntimeException extends RuntimeException {
+  public FileBasedRosettaConfigurationRuntimeException(String message, Exception e) {
+    super(message, e);
+  }
+}


### PR DESCRIPTION
Throw an exception if the Rosetta Configuration exists but cannot be parsed.

Previously if the config could not be parsed the error was logged but the BSP continued working with a null configuration. This could be misleading - especially if the client logging is not set up correctly we will miss this. We want this to be a breaking event.

## Type of change

Please delete options that are not relevant.

[x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
