### PR TITLE
Fix usage of `default` with multi-cardinality in aliases 

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorDefaultTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorDefaultTest.java
@@ -1,0 +1,405 @@
+package com.regnosys.rosetta.generator.java.function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
+import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaTestInjectorProvider.class)
+public class FunctionGeneratorDefaultTest {
+
+	@Inject
+	private FunctionGeneratorHelper functionGeneratorHelper;
+	@Inject
+	private CodeGeneratorTestHelper generatorTestHelper;
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresent() {
+		var model = """
+				func Foo:
+					inputs:
+						left string (0..1)
+						right string (1..1)
+					output: result string (1..1)
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var result = functionGeneratorHelper.invokeFunc(foo, String.class, "a", "b");
+
+		assertEquals("a", result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToRightWhenLeftIsEmpty() {
+		var model = """
+				func Foo:
+					inputs:
+						left string (0..1)
+						right string (1..1)
+					output: result string (1..1)
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var result = functionGeneratorHelper.invokeFunc(foo, String.class, null, "b");
+
+		assertEquals("b", result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresentWithAlias() {
+		var model = """
+				func Foo:
+					inputs:
+						left string (0..1)
+						right string (1..1)
+					output:
+						result string (1..1)
+
+					alias aliasResult:
+						left default right
+
+					set result:
+						aliasResult
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var result = functionGeneratorHelper.invokeFunc(foo, String.class, "a", "b");
+
+		assertEquals("a", result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinality() {
+		var model = """
+				func Foo:
+					inputs:
+						left string (1..*)
+						right string (1..*)
+					output: result string (1..*)
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of("a1", "a2"), List.of("b1", "b2"));
+
+		assertEquals(List.of("a1", "a2"), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToRightWhenLeftIsEmptyMultiCardinality() {
+		var model = """
+				func Foo:
+					inputs:
+						left string (1..*)
+						right string (1..*)
+					output: result string (1..*)
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(), List.of("b1", "b2"));
+
+		assertEquals(List.of("b1", "b2"), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexType() {
+		var model = """
+				type Bar:
+					attr string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Bar (1..*)
+					output:
+						result Bar (1..*)
+
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var a1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "a1"));
+		var a2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "a2"));
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(a1, a2), List.of(b1, b2));
+
+		assertEquals(List.of(a1, a2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToRightWhenBothSidesPresentMultiCardinalityComplexType() {
+		var model = """
+				type Bar:
+					attr string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Bar (1..*)
+					output:
+						result Bar (1..*)
+
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(), List.of(b1, b2));
+
+		assertEquals(List.of(b1, b2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexSubType() {
+		var model = """
+				type Bar:
+					attr1 string (0..1)
+
+				type Baz extends Bar:
+					attr2 string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Baz (1..*)
+					output:
+						result Bar (1..*)
+
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var a1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr1", "a1"));
+		var a2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr1", "a2"));
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Baz", Map.of("attr2", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Baz", Map.of("attr2", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(a1, a2), List.of(b1, b2));
+
+		assertEquals(List.of(a1, a2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToRightWhenBothSidesPresentMultiCardinalityComplexSubType() {
+		var model = """
+				type Bar:
+					attr1 string (0..1)
+
+				type Baz extends Bar:
+					attr2 string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Baz (1..*)
+					output:
+						result Bar (1..*)
+
+					set result:
+						left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Baz", Map.of("attr2", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Baz", Map.of("attr2", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(), List.of(b1, b2));
+
+		assertEquals(List.of(b1, b2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexTypeWithAlias() {
+		var model = """
+				type Bar:
+					attr string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Bar (1..*)
+					output:
+						result Bar (1..*)
+
+					alias aliasResult:
+						left default right
+
+					set result:
+						aliasResult
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var a1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "a1"));
+		var a2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "a2"));
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(a1, a2), List.of(b1, b2));
+
+		assertEquals(List.of(a1, a2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToRightWhenBothSidesPresentMultiCardinalityComplexTypeWithAlias() {
+		var model = """
+				type Bar:
+					attr string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Bar (1..*)
+					output:
+						result Bar (1..*)
+
+					alias aliasResult:
+						left default right
+
+					set result:
+						aliasResult
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(), List.of(b1, b2));
+
+		assertEquals(List.of(b1, b2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexTypeWithIf() {
+		var model = """
+				type Bar:
+					attr string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Bar (1..*)
+						cond boolean (1..1)
+					output:
+						result Bar (1..*)
+
+					set result:
+						if cond
+						then left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var a1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "a1"));
+		var a2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "a2"));
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(a1, a2), List.of(b1, b2), true);
+
+		assertEquals(List.of(a1, a2), result);
+	}
+
+	@Test
+	void defaultOperatorEvaluatesToRightWhenBothSidesPresentMultiCardinalityComplexTypeWithIf() {
+		var model = """
+				type Bar:
+					attr string (0..1)
+
+				func Foo:
+					inputs:
+						left Bar (1..*)
+						right Bar (1..*)
+						cond boolean (1..1)
+					output:
+						result Bar (1..*)
+
+					set result:
+						if cond
+						then left default right
+				""";
+		var code = generatorTestHelper.generateCode(model);
+
+		var classes = generatorTestHelper.compileToClasses(code);
+
+		var foo = functionGeneratorHelper.createFunc(classes, "Foo");
+
+		var b1 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b1"));
+		var b2 = generatorTestHelper.createInstanceUsingBuilder(classes, "Bar", Map.of("attr", "b2"));
+
+		var result = functionGeneratorHelper.invokeFunc(foo, List.class, List.of(), List.of(b1, b2), true);
+
+		assertEquals(List.of(b1, b2), result);
+	}
+}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.xtend
@@ -9,6 +9,7 @@ import com.rosetta.model.lib.meta.Key
 import com.rosetta.model.lib.meta.Reference
 import com.rosetta.model.lib.records.Date
 import com.rosetta.model.metafields.MetaFields
+import com.rosetta.util.DottedPath
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -31,7 +32,6 @@ import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.core.IsCollectionContaining.hasItems
 import static org.junit.Assert.assertThrows
 import static org.junit.jupiter.api.Assertions.*
-import com.rosetta.util.DottedPath
 
 @ExtendWith(InjectionExtension)
 @InjectWith(RosettaTestInjectorProvider)
@@ -1050,198 +1050,6 @@ class FunctionGeneratorTest {
 				then ab -> B -> val
 		'''.generateCode
         code.compileToClasses
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToLeftWhenBothSidesPresent() {
-		val code = '''
-		func Foo:
-			inputs:
-				left string (0..1)
-				right string (1..1)
-			output: result string (1..1)
-			set result:
-				left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		assertEquals("a", foo.invokeFunc(String, #["a", "b"]))
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToRightWhenLeftIsEmpty() {
-		val code = '''
-		func Foo:
-			inputs:
-				left string (0..1)
-				right string (1..1)
-			output: result string (1..1)
-			set result:
-				left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		assertEquals("b", foo.invokeFunc(String, #[null, "b"]))
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinality() {
-		val code = '''
-		func Foo:
-			inputs:
-				left string (1..*)
-				right string (1..*)
-			output: result string (1..*)
-			set result:
-				left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		assertEquals(#["a1", "a2"], foo.invokeFunc(String, #[#["a1", "a2"], #["b1", "b2"]]))
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexType() {
-		val code = '''
-		type Bar:
-			attr string (0..1)
-		
-		func Foo:
-			inputs:
-				left Bar (1..*)
-				right Bar (1..*)
-			output: 
-				result Bar (1..*)
-			
-			set result:
-				left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		val a1 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "a1"
-			})
-		val a2 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "a2"
-			})
-		val b1 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "b1"
-			})
-		val b2 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "b2"
-			})
-		
-		assertEquals(#[a1, a2], foo.invokeFunc(String, #[#[a1, a2], #[b1, b2]]))
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexTypeWithIf() {
-		val code = '''
-		type Bar:
-			attr string (0..1)
-		
-		func Foo:
-			inputs:
-				left Bar (1..*)
-				right Bar (1..*)
-				cond boolean (1..1)
-			output: 
-				result Bar (1..*)
-			
-			set result:
-				if cond
-				then left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		val a1 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "a1"
-			})
-		val a2 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "a2"
-			})
-		val b1 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "b1"
-			})
-		val b2 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr" -> "b2"
-			})
-		
-		assertEquals(#[a1, a2], foo.invokeFunc(String, #[#[a1, a2], #[b1, b2], true]))
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToLeftWhenBothSidesPresentMultiCardinalityComplexType2() {
-		val code = '''
-		type Bar:
-			attr1 string (0..1)
-
-		type Baz extends Bar:
-			attr2 string (0..1)
-		
-		func Foo:
-			inputs:
-				left Bar (1..*)
-				right Baz (1..*)
-			output: 
-				result Bar (1..*)
-			
-			set result:
-				left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		val a1 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr1" -> "a1"
-			})
-		val a2 = classes.createInstanceUsingBuilder("Bar", #{
-				"attr1" -> "a2"
-			})
-		val b1 = classes.createInstanceUsingBuilder("Baz", #{
-				"attr2" -> "b1"
-			})
-		val b2 = classes.createInstanceUsingBuilder("Baz", #{
-				"attr2" -> "b2"
-			})
-		
-		assertEquals(#[a1, a2], foo.invokeFunc(String, #[#[a1, a2], #[b1, b2]]))
-	}
-	
-	@Test
-	def void defaultOperatorEvaluatesToRightWhenLeftIsEmptyMultiCardinality() {
-		val code = '''
-		func Foo:
-			inputs:
-				left string (1..*)
-				right string (1..*)
-			output: result string (1..*)
-			set result:
-				left default right
-		'''.generateCode
-		
-		val classes = code.compileToClasses
-		
-		val foo = classes.createFunc("Foo");
-		
-		assertEquals(#["b1", "b2"], foo.invokeFunc(String, #[#[], #["b1", "b2"]]))
 	}
 	
 	@Test

--- a/rune-lang/src/main/java/com/regnosys/rosetta/types/CardinalityProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/types/CardinalityProvider.java
@@ -326,7 +326,7 @@ public class CardinalityProvider extends RosettaExpressionSwitch<Boolean, Map<Ro
 	
 	@Override
 	protected Boolean caseDefaultOperation(DefaultOperation expr, Map<RosettaSymbol, Boolean> cycleTracker) {
-		return false;
+		return safeIsMulti(expr.getLeft(), cycleTracker) || safeIsMulti(expr.getRight(), cycleTracker);
 	}
 	
 	@Override


### PR DESCRIPTION
- Fix `default` with multi-cardinality inputs when used in an `alias`
- Migrated related tests from xtend to Java

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
