### PR TITLE
Fix GenerateRosetta MWE config

### DIFF
--- a/rune-lang/src/main/java/com/regnosys/rosetta/GenerateRosetta.mwe2
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/GenerateRosetta.mwe2
@@ -82,7 +82,7 @@ Workflow {
 				generateStub = true
 			}
 			junitSupport = {
-				junitVersion = "5"
+				generateStub = false
 			}
 			formatter = {
 				generateStub = true


### PR DESCRIPTION
Builds started failing due to `GenerateRosetta.mwe2` config setting, probably due to a change in transient dependencies.  However given that `runtimeTest` is already disabled in this config, then the `junitSupport` can be disabled.

Before:
```
junitSupport = {
    junitVersion = "5"
}
```
After:
```
junitSupport = {
    generateStub = false
}
```

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
