### PR TITLE
Fix local validation scope memory leak

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
@@ -1,5 +1,6 @@
 package com.regnosys.rosetta.validation;
 
+import com.regnosys.rosetta.validation.names.ClusterScope;
 import com.regnosys.rosetta.validation.names.RosettaUniqueNamesConfig;
 import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
 import com.regnosys.rosetta.tests.util.ModelHelper;
@@ -9,6 +10,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.ISelectable;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.junit.jupiter.api.Assertions;
@@ -159,7 +161,7 @@ public class NamesValidationTest {
                     attr int (1..1)
                 """);
         EClass clusterType = SimplePackage.eINSTANCE.getAttribute();
-        Function<IEObjectDescription, org.eclipse.xtext.resource.ISelectable> scopeFunction =
+        Function<IEObjectDescription, ISelectable> scopeFunction =
                 uniqueNamesConfig.getDuplicationCluster(clusterType).clusterScope().getScope(model.eResource(), clusterType);
 
         IResourceDescription resourceDescription = resourceDescriptionManager.getResourceDescription(model.eResource());
@@ -174,8 +176,8 @@ public class NamesValidationTest {
     }
 
     private int localValidationScopeCacheSize(Object clusterScope, Resource resource, EClass clusterType) {
-        Function<IEObjectDescription, org.eclipse.xtext.resource.ISelectable> function =
-                ((com.regnosys.rosetta.validation.names.ClusterScope) clusterScope).getScope(resource, clusterType);
+        Function<IEObjectDescription, ISelectable> function =
+                ((ClusterScope) clusterScope).getScope(resource, clusterType);
         IResourceDescription resourceDescription = resourceDescriptionManager.getResourceDescription(resource);
         List<IEObjectDescription> descriptions = new ArrayList<>();
         resourceDescription.getExportedObjectsByType(clusterType).forEach(descriptions::add);
@@ -185,7 +187,7 @@ public class NamesValidationTest {
         return reflectedCacheSize(function);
     }
 
-    private static int reflectedCacheSize(Object scopedFunction) {
+    private static int reflectedCacheSize(Function<IEObjectDescription, ISelectable> scopedFunction) {
         List<Field> mapFields = new ArrayList<>();
         for (Field field : scopedFunction.getClass().getDeclaredFields()) {
             if (Map.class.isAssignableFrom(field.getType())) {
@@ -193,10 +195,10 @@ public class NamesValidationTest {
             }
         }
         if (mapFields.isEmpty()) {
-            throw new AssertionError("Could not find captured localValidationScopes map on scope function.");
+            throw new RuntimeException("Could not find captured localValidationScopes map on scope function.");
         }
         if (mapFields.size() > 1) {
-            throw new AssertionError("Expected a single captured map on scope function, found " + mapFields.size() + ".");
+            throw new RuntimeException("Expected a single captured map on scope function, found " + mapFields.size() + ".");
         }
         Field cacheField = mapFields.getFirst();
         cacheField.setAccessible(true);
@@ -205,9 +207,9 @@ public class NamesValidationTest {
             if (value instanceof Map<?, ?> cache) {
                 return cache.size();
             }
-            throw new AssertionError("Expected captured localValidationScopes to be a Map.");
+            throw new RuntimeException("Expected captured localValidationScopes to be a Map.");
         } catch (IllegalAccessException e) {
-            throw new AssertionError("Unable to inspect localValidationScopes via reflection.", e);
+            throw new RuntimeException("Unable to inspect localValidationScopes via reflection.", e);
         }
     }
 

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
@@ -1,14 +1,26 @@
 package com.regnosys.rosetta.validation;
 
+import com.regnosys.rosetta.validation.names.RosettaUniqueNamesConfig;
 import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
 import com.regnosys.rosetta.tests.util.ModelHelper;
 import com.regnosys.rosetta.tests.validation.RosettaValidationTestHelper;
+import com.regnosys.rosetta.rosetta.simple.SimplePackage;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.inject.Inject;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.function.Function;
 
 import static com.regnosys.rosetta.rosetta.RosettaPackage.Literals.TYPE_PARAMETER;
 
@@ -19,6 +31,10 @@ public class NamesValidationTest {
     private RosettaValidationTestHelper validationTestHelper;
     @Inject
     private ModelHelper modelHelper;
+    @Inject
+    private RosettaUniqueNamesConfig uniqueNamesConfig;
+    @Inject
+    private IResourceDescription.Manager resourceDescriptionManager;
     
     @Test
     void testDuplicateType() {
@@ -108,5 +124,80 @@ public class NamesValidationTest {
 				""");
         validationTestHelper.assertError(model, TYPE_PARAMETER, null,
                 "Duplicate parameter name `digits`.");
+    }
+
+    @Test
+    void testLocalValidationScopeCacheDoesNotPersistAcrossValidationContexts() {
+        var clusterScope = uniqueNamesConfig.getDuplicationCluster(SimplePackage.eINSTANCE.getAttribute()).clusterScope();
+
+        var modelV1 = modelHelper.parseRosetta("""
+                type Foo:
+                    a int (1..1)
+                """);
+        validationTestHelper.assertNoIssues(modelV1);
+        OptionalInt cacheSizeAfterV1 = persistentLocalValidationScopeCacheSize(clusterScope);
+
+        var modelV2 = modelHelper.parseRosetta("""
+                type Bar:
+                    b int (1..1)
+                """);
+        validationTestHelper.assertNoIssues(modelV2);
+        OptionalInt cacheSizeAfterV2 = persistentLocalValidationScopeCacheSize(clusterScope);
+
+        if (cacheSizeAfterV1.isPresent() && cacheSizeAfterV2.isPresent()) {
+            Assertions.assertEquals(cacheSizeAfterV1.getAsInt(), cacheSizeAfterV2.getAsInt(),
+                    "Persistent local validation scope cache grew across independent validation contexts.");
+        }
+        Assertions.assertFalse(cacheSizeAfterV2.isPresent(),
+                "Local cluster scope must not keep a persistent localValidationScopes cache.");
+    }
+
+    @Test
+    void testLocalScopeStillFindsDuplicateAttributes() {
+        var model = modelHelper.parseRosetta("""
+                type Foo:
+                    attr int (1..1)
+                    attr int (1..1)
+                """);
+        EClass clusterType = SimplePackage.eINSTANCE.getAttribute();
+        Function<IEObjectDescription, org.eclipse.xtext.resource.ISelectable> scopeFunction =
+                uniqueNamesConfig.getDuplicationCluster(clusterType).clusterScope().getScope(model.eResource(), clusterType);
+
+        IResourceDescription resourceDescription = resourceDescriptionManager.getResourceDescription(model.eResource());
+        List<IEObjectDescription> attributes = new ArrayList<>();
+        resourceDescription.getExportedObjectsByType(clusterType).forEach(attributes::add);
+        Assertions.assertFalse(attributes.isEmpty(), "Expected exported attribute descriptions.");
+
+        IEObjectDescription attribute = attributes.getFirst();
+        var sameName = scopeFunction.apply(attribute).getExportedObjects(clusterType, attribute.getName(), false);
+        Assertions.assertEquals(2, count(sameName),
+                "Local scope should still include both duplicate attributes.");
+    }
+
+    private static OptionalInt persistentLocalValidationScopeCacheSize(Object clusterScope) {
+        Field cacheField;
+        try {
+            cacheField = clusterScope.getClass().getDeclaredField("localValidationScopes");
+        } catch (NoSuchFieldException e) {
+            return OptionalInt.empty();
+        }
+        cacheField.setAccessible(true);
+        try {
+            Object value = cacheField.get(clusterScope);
+            if (value instanceof Map<?, ?> cache) {
+                return OptionalInt.of(cache.size());
+            }
+            throw new AssertionError("Expected localValidationScopes to be a Map.");
+        } catch (IllegalAccessException e) {
+            throw new AssertionError("Unable to inspect localValidationScopes via reflection.", e);
+        }
+    }
+
+    private static int count(Iterable<?> values) {
+        int count = 0;
+        for (Object ignored : values) {
+            count++;
+        }
+        return count;
     }
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
@@ -1,5 +1,6 @@
 package com.regnosys.rosetta.validation;
 
+import com.google.common.collect.Iterables;
 import com.regnosys.rosetta.validation.names.ClusterScope;
 import com.regnosys.rosetta.validation.names.RosettaUniqueNamesConfig;
 import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
@@ -171,7 +172,7 @@ public class NamesValidationTest {
 
         IEObjectDescription attribute = attributes.getFirst();
         var sameName = scopeFunction.apply(attribute).getExportedObjects(clusterType, attribute.getName(), false);
-        Assertions.assertEquals(2, count(sameName),
+        Assertions.assertEquals(2, Iterables.size(sameName),
                 "Local scope should still include both duplicate attributes.");
     }
 
@@ -211,13 +212,5 @@ public class NamesValidationTest {
         } catch (IllegalAccessException e) {
             throw new RuntimeException("Unable to inspect localValidationScopes via reflection.", e);
         }
-    }
-
-    private static int count(Iterable<?> values) {
-        int count = 0;
-        for (Object ignored : values) {
-            count++;
-        }
-        return count;
     }
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/NamesValidationTest.java
@@ -6,6 +6,7 @@ import com.regnosys.rosetta.tests.util.ModelHelper;
 import com.regnosys.rosetta.tests.validation.RosettaValidationTestHelper;
 import com.regnosys.rosetta.rosetta.simple.SimplePackage;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.testing.InjectWith;
@@ -19,7 +20,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
 import java.util.function.Function;
 
 import static com.regnosys.rosetta.rosetta.RosettaPackage.Literals.TYPE_PARAMETER;
@@ -128,28 +128,27 @@ public class NamesValidationTest {
 
     @Test
     void testLocalValidationScopeCacheDoesNotPersistAcrossValidationContexts() {
-        var clusterScope = uniqueNamesConfig.getDuplicationCluster(SimplePackage.eINSTANCE.getAttribute()).clusterScope();
+        EClass clusterType = SimplePackage.eINSTANCE.getAttribute();
+        var clusterScope = uniqueNamesConfig.getDuplicationCluster(clusterType).clusterScope();
 
         var modelV1 = modelHelper.parseRosetta("""
                 type Foo:
                     a int (1..1)
                 """);
         validationTestHelper.assertNoIssues(modelV1);
-        OptionalInt cacheSizeAfterV1 = persistentLocalValidationScopeCacheSize(clusterScope);
+        int cacheSizeAfterV1 = localValidationScopeCacheSize(clusterScope, modelV1.eResource(), clusterType);
 
         var modelV2 = modelHelper.parseRosetta("""
                 type Bar:
                     b int (1..1)
                 """);
         validationTestHelper.assertNoIssues(modelV2);
-        OptionalInt cacheSizeAfterV2 = persistentLocalValidationScopeCacheSize(clusterScope);
+        int cacheSizeAfterV2 = localValidationScopeCacheSize(clusterScope, modelV2.eResource(), clusterType);
 
-        if (cacheSizeAfterV1.isPresent() && cacheSizeAfterV2.isPresent()) {
-            Assertions.assertEquals(cacheSizeAfterV1.getAsInt(), cacheSizeAfterV2.getAsInt(),
-                    "Persistent local validation scope cache grew across independent validation contexts.");
-        }
-        Assertions.assertFalse(cacheSizeAfterV2.isPresent(),
-                "Local cluster scope must not keep a persistent localValidationScopes cache.");
+        Assertions.assertEquals(cacheSizeAfterV1, cacheSizeAfterV2,
+                "Local validation-scope cache should not accumulate across independent validation contexts.");
+        Assertions.assertEquals(1, cacheSizeAfterV1,
+                "Expected exactly one local-scope cache entry for one attribute container.");
     }
 
     @Test
@@ -174,20 +173,39 @@ public class NamesValidationTest {
                 "Local scope should still include both duplicate attributes.");
     }
 
-    private static OptionalInt persistentLocalValidationScopeCacheSize(Object clusterScope) {
-        Field cacheField;
-        try {
-            cacheField = clusterScope.getClass().getDeclaredField("localValidationScopes");
-        } catch (NoSuchFieldException e) {
-            return OptionalInt.empty();
+    private int localValidationScopeCacheSize(Object clusterScope, Resource resource, EClass clusterType) {
+        Function<IEObjectDescription, org.eclipse.xtext.resource.ISelectable> function =
+                ((com.regnosys.rosetta.validation.names.ClusterScope) clusterScope).getScope(resource, clusterType);
+        IResourceDescription resourceDescription = resourceDescriptionManager.getResourceDescription(resource);
+        List<IEObjectDescription> descriptions = new ArrayList<>();
+        resourceDescription.getExportedObjectsByType(clusterType).forEach(descriptions::add);
+        for (IEObjectDescription description : descriptions) {
+            function.apply(description);
         }
+        return reflectedCacheSize(function);
+    }
+
+    private static int reflectedCacheSize(Object scopedFunction) {
+        List<Field> mapFields = new ArrayList<>();
+        for (Field field : scopedFunction.getClass().getDeclaredFields()) {
+            if (Map.class.isAssignableFrom(field.getType())) {
+                mapFields.add(field);
+            }
+        }
+        if (mapFields.isEmpty()) {
+            throw new AssertionError("Could not find captured localValidationScopes map on scope function.");
+        }
+        if (mapFields.size() > 1) {
+            throw new AssertionError("Expected a single captured map on scope function, found " + mapFields.size() + ".");
+        }
+        Field cacheField = mapFields.getFirst();
         cacheField.setAccessible(true);
         try {
-            Object value = cacheField.get(clusterScope);
+            Object value = cacheField.get(scopedFunction);
             if (value instanceof Map<?, ?> cache) {
-                return OptionalInt.of(cache.size());
+                return cache.size();
             }
-            throw new AssertionError("Expected localValidationScopes to be a Map.");
+            throw new AssertionError("Expected captured localValidationScopes to be a Map.");
         } catch (IllegalAccessException e) {
             throw new AssertionError("Unable to inspect localValidationScopes via reflection.", e);
         }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/ClusterScopes.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/ClusterScopes.java
@@ -64,7 +64,6 @@ public class ClusterScopes {
     private static abstract class LocalClusterScope<Parent, Child extends RosettaNamed> implements ClusterScope {
         private final Class<Child> childClass;
 
-        private final Map<LocalScopeKey<Parent>, ISelectable> localValidationScopes = new HashMap<>();
         private record LocalScopeKey<Parent>(Parent container, EClass clusterType) {}
 
         public LocalClusterScope(Class<Child> childClass) {
@@ -81,6 +80,7 @@ public class ClusterScopes {
 
         @Override
         public Function<IEObjectDescription, ISelectable> getScope(Resource resource, EClass clusterType) {
+            Map<LocalScopeKey<Parent>, ISelectable> localValidationScopes = new HashMap<>();
             return description -> {
                 Parent parent = getParentFromChildDescription(description);
                 LocalScopeKey<Parent> key = new LocalScopeKey<>(parent, clusterType);


### PR DESCRIPTION
Moved the local validation-scope cache from a `LocalClusterScope` field into the function created by `getScope(...)`.

Previously, the cache lived as long as the `LocalClusterScope` instance and could retain parent EMF objects across independent validation contexts, causing memory to accumulate and potentially leaking old model/resource graphs. The cache is now created per validation scope function, so it is still reused during a single validation pass, but is discarded with the validation context instead of persisting across validations.