### PR TITLE
Add readOnlyNamespaces config and read-only-namespace CI check

### DIFF
--- a/.github/scripts/check_readonly_namespaces.py
+++ b/.github/scripts/check_readonly_namespaces.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Fail the build when a read-only Rune namespace is changed.
+
+The read-only namespaces are read from the ``readOnlyNamespaces`` list of a
+``rune-config.yml`` file, so they are configured in a single place. A change to a
+``.rosetta`` file is a violation when the file's namespace is read-only either:
+
+* **before** the change -- you may not modify, delete or move a file *out of* a
+  read-only namespace; or
+* **after** the change -- you may not add a file to, or move a file *into*, a
+  read-only namespace.
+
+The build also fails if a configured pattern matches no namespace in the
+repository, which catches stale or mistyped patterns.
+
+The checker is self-contained: it only uses the Python standard library and git.
+"""
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Matches `namespace foo.bar`, optionally preceded by the `override` keyword and optionally quoted.
+NAMESPACE_RE = re.compile(r'^\s*(?:override\s+)?namespace\s+"?([A-Za-z0-9_.]+)"?', re.MULTILINE)
+
+
+def git(*args):
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout
+
+
+def git_show(ref, path):
+    """Content of `path` at `ref`, or None if it does not exist there."""
+    result = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True)
+    return result.stdout if result.returncode == 0 else None
+
+
+def namespace_of(text):
+    if text is None:
+        return None
+    match = NAMESPACE_RE.search(text)
+    return match.group(1) if match else None
+
+
+def read_readonly_namespaces(config_path):
+    """Read the `readOnlyNamespaces` list from a rune-config.yml file."""
+    config = Path(config_path)
+    if not config.is_file():
+        return []
+    patterns = []
+    in_block = False
+    for raw in config.read_text(encoding="utf-8").splitlines():
+        line = re.sub(r'\s+#.*$', '', raw).rstrip()  # strip trailing comments
+        if not line.strip():
+            continue
+        key = re.match(r'^readOnlyNamespaces\s*:\s*(.*)$', line)
+        if key:
+            inline = key.group(1).strip()
+            if inline.startswith("["):
+                patterns.extend(_clean(v) for v in inline.strip("[]").split(",") if _clean(v))
+                in_block = False
+            else:
+                in_block = True
+            continue
+        if in_block:
+            item = re.match(r'^\s*-\s*(.+?)\s*$', line)
+            if item:
+                value = _clean(item.group(1))
+                if value:
+                    patterns.append(value)
+            elif not line[:1].isspace():
+                in_block = False  # reached the next top-level key
+    return patterns
+
+
+def _clean(value):
+    return value.strip().strip('"').strip("'")
+
+
+def changed_rosetta_files(base):
+    """Yield (status, old_path, new_path) for changed files between base and HEAD."""
+    out = git("diff", "--name-status", "-z", f"{base}...HEAD")
+    tokens = out.split("\0")
+    i = 0
+    while i < len(tokens):
+        status = tokens[i]
+        if not status:
+            i += 1
+            continue
+        code = status[0]
+        if code in ("R", "C"):
+            yield code, tokens[i + 1], tokens[i + 2]
+            i += 3
+        else:
+            yield code, tokens[i + 1], tokens[i + 1]
+            i += 2
+
+
+def matches_any(namespace, patterns):
+    return namespace is not None and any(fnmatch.fnmatchcase(namespace, pattern) for pattern in patterns)
+
+
+def repository_namespaces(root):
+    namespaces = set()
+    for file in Path(root).rglob("*.rosetta"):
+        try:
+            namespace = namespace_of(file.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        if namespace:
+            namespaces.add(namespace)
+    return namespaces
+
+
+def describe(code, old, new):
+    verb = {"A": "added", "M": "modified", "D": "deleted", "R": "renamed", "C": "copied"}.get(code, "changed")
+    return f"{new} ({verb})" if old == new else f"{old} -> {new} ({verb})"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify that read-only Rune namespaces are not changed.")
+    parser.add_argument("--base", required=True, help="Git ref to diff HEAD against.")
+    parser.add_argument("--config", required=True,
+                        help="Path to the rune-config.yml whose readOnlyNamespaces lists the read-only patterns.")
+    parser.add_argument("--root", default=".", help="Directory to scan for .rosetta files.")
+    args = parser.parse_args()
+
+    patterns = read_readonly_namespaces(args.config)
+    if not patterns:
+        print(f"No readOnlyNamespaces configured in '{args.config}'; nothing to check.")
+        return 0
+
+    failures = []
+
+    # 1. Stale-pattern check: every configured pattern must match at least one namespace.
+    all_namespaces = repository_namespaces(args.root)
+    for pattern in patterns:
+        if not any(fnmatch.fnmatchcase(ns, pattern) for ns in all_namespaces):
+            failures.append(
+                f"Read-only namespace pattern '{pattern}' does not match any .rosetta namespace "
+                f"under '{args.root}' (stale or mistyped pattern?)."
+            )
+
+    # 2. Changed-file check: a file may not be read-only before OR after the change.
+    for code, old, new in changed_rosetta_files(args.base):
+        if not (old.endswith(".rosetta") or new.endswith(".rosetta")):
+            continue
+        before = None if code in ("A", "C") else namespace_of(git_show(args.base, old))
+        after = None if code == "D" else namespace_of(read_worktree(new))
+        if matches_any(before, patterns):
+            failures.append(f"{describe(code, old, new)} changes a file in read-only namespace '{before}'.")
+        elif matches_any(after, patterns):
+            failures.append(f"{describe(code, old, new)} moves a file into read-only namespace '{after}'.")
+
+    if failures:
+        print("Read-only namespace check FAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print(f"Read-only namespace check passed ({len(patterns)} pattern(s) checked).")
+    return 0
+
+
+def read_worktree(path):
+    file = Path(path)
+    if not file.is_file():
+        return None
+    return file.read_text(encoding="utf-8", errors="replace")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-readonly-namespaces.yml
+++ b/.github/workflows/verify-readonly-namespaces.yml
@@ -1,0 +1,92 @@
+name: Verify read-only namespaces
+
+# Reusable workflow that fails when a read-only Rune namespace is
+# changed in a pull request. The read-only namespaces are read from the
+# `readOnlyNamespaces` list of the project's rune-config.yml. Call it with:
+#
+#   jobs:
+#     readonly-namespaces:
+#       uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
+#       with:
+#         config-path: rune-config.yml
+#
+on:
+  workflow_call:
+    inputs:
+      config-path:
+        description: "Path to the rune-config.yml whose readOnlyNamespaces lists the read-only namespaces."
+        required: true
+        type: string
+      base-ref:
+        description: "Git ref to diff HEAD against. Defaults to the pull request base branch, or the repository default branch."
+        required: false
+        default: ""
+        type: string
+      root:
+        description: "Directory under which to scan for .rosetta files."
+        required: false
+        default: "."
+        type: string
+      checker-ref:
+        description: "Ref of finos/rune-dsl from which to fetch the checker script."
+        required: false
+        default: "main"
+        type: string
+      bypass-label:
+        description: "Pull request label that skips the check, to allow an intentional one-off change to a read-only namespace."
+        required: false
+        default: "override-readonly-namespaces"
+        type: string
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository under test
+        uses: actions/checkout@v6
+        with:
+          # Full history so HEAD can be diffed against the base ref.
+          fetch-depth: 0
+
+      - name: Check out the read-only-namespace checker
+        uses: actions/checkout@v6
+        with:
+          repository: finos/rune-dsl
+          ref: ${{ inputs.checker-ref }}
+          path: .rune-dsl-checker
+          sparse-checkout: .github/scripts
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Resolve base ref
+        id: base
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.base-ref }}" ]; then
+            base="${{ inputs.base-ref }}"
+          elif [ -n "${{ github.base_ref }}" ]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            base="origin/${{ github.base_ref }}"
+          else
+            git fetch --no-tags origin "${{ github.event.repository.default_branch }}"
+            base="origin/${{ github.event.repository.default_branch }}"
+          fi
+          echo "ref=$base" >> "$GITHUB_OUTPUT"
+          echo "Diffing against base ref: $base"
+
+      - name: Check read-only namespaces
+        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.bypass-label) }}
+        shell: bash
+        run: |
+          python .rune-dsl-checker/.github/scripts/check_readonly_namespaces.py \
+            --base "${{ steps.base.outputs.ref }}" \
+            --config "${{ inputs.config-path }}" \
+            --root "${{ inputs.root }}"
+
+      - name: Read-only namespace check bypassed
+        if: ${{ contains(github.event.pull_request.labels.*.name, inputs.bypass-label) }}
+        run: |
+          echo "::notice::Read-only namespace check skipped because the '${{ inputs.bypass-label }}' label is present on this pull request."

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ com.regnosys.rosetta.web/
 .vscode/
 /rosetta-ide/vscode/node_modules/
 
+# Python
+__pycache__/
+*.pyc
+
 # Docusaurus website
 website/.docusaurus
 website/build

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/RuneConfigurationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/RuneConfigurationTest.java
@@ -40,7 +40,8 @@ public class RuneConfigurationTest {
 		assertFalse(filter.test("foo"));
 		assertTrue(filter.test("abc.def"));
 		assertFalse(filter.test("abc.def.sub"));
-		
+
+		assertEquals(java.util.List.of("com.rosetta.model.*", "abc.def"), config.getReadOnlyNamespaces());
 	}
 	
 

--- a/rune-integration-tests/src/test/resources/rune-config-test.yml
+++ b/rune-integration-tests/src/test/resources/rune-config-test.yml
@@ -5,3 +5,6 @@ generators:
   namespaces:
   - xyz.*   # project namespace
   - abc.def # forked namespace
+readOnlyNamespaces:
+- com.rosetta.model.*
+- abc.def

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneConfiguration.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneConfiguration.java
@@ -1,5 +1,6 @@
 package com.regnosys.rosetta.config;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -7,17 +8,27 @@ public class RuneConfiguration {
 	private final RuneModelConfiguration model;
 	private final List<RuneDependencyConfiguration> dependencies;
 	private final RuneGeneratorsConfiguration generators;
-	
-	public RuneConfiguration(RuneModelConfiguration model, 
+	private final List<String> readOnlyNamespaces;
+
+	public RuneConfiguration(RuneModelConfiguration model,
 			List<RuneDependencyConfiguration> dependencies,
 			RuneGeneratorsConfiguration generators) {
+		this(model, dependencies, generators, Collections.emptyList());
+	}
+
+	public RuneConfiguration(RuneModelConfiguration model,
+			List<RuneDependencyConfiguration> dependencies,
+			RuneGeneratorsConfiguration generators,
+			List<String> readOnlyNamespaces) {
 		Objects.requireNonNull(model);
 		Objects.requireNonNull(dependencies);
 		Objects.requireNonNull(generators);
-		
+		Objects.requireNonNull(readOnlyNamespaces);
+
 		this.model = model;
 		this.dependencies = dependencies;
 		this.generators = generators;
+		this.readOnlyNamespaces = readOnlyNamespaces;
 	}
 
 	public RuneModelConfiguration getModel() {
@@ -30,5 +41,9 @@ public class RuneConfiguration {
 
 	public RuneGeneratorsConfiguration getGenerators() {
 		return generators;
+	}
+
+	public List<String> getReadOnlyNamespaces() {
+		return readOnlyNamespaces;
 	}
 }

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationMixin.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationMixin.java
@@ -13,5 +13,6 @@ public abstract class RuneConfigurationMixin {
 	public RuneConfigurationMixin(
 			@JsonProperty("model") RuneModelConfiguration model,
 			@JsonProperty("dependencies") List<RuneDependencyConfiguration> dependencies,
-			@JsonProperty("generators") RuneGeneratorsConfiguration generators) {}
+			@JsonProperty("generators") RuneGeneratorsConfiguration generators,
+			@JsonProperty("readOnlyNamespaces") List<String> readOnlyNamespaces) {}
 }

--- a/website/docs/developers/read-only-namespaces.mdx
+++ b/website/docs/developers/read-only-namespaces.mdx
@@ -1,0 +1,84 @@
+---
+title: Read-only namespaces
+sidebar_label: Read-only namespaces
+description: "Use the read-only namespaces GitHub workflow to prevent manual changes to namespaces that are managed externally."
+slug: /developers/read-only-namespaces
+---
+
+# Read-only namespaces
+
+Some namespaces in a model are not authored by hand: they are generated from an external schema —
+for example, a namespace produced by importing an XSD or a JSON schema. The generated Rune is a
+faithful representation of that schema, so editing those files manually would make the model drift
+away from the schema it is meant to mirror, silently breaking the correspondence between them.
+
+To prevent that, such namespaces can be marked as **read-only**. They are listed in the
+`rune-config.yml`, and a supplied GitHub workflow then fails any pull request that hand-edits a
+read-only namespace — until someone deliberately decides to allow it. Nothing is locked forever;
+the check is a safety net that turns an accidental manual edit into a conscious decision (and the
+right way to update a read-only namespace is to re-run the import that generated it).
+
+## Declaring the read-only namespaces
+
+Read-only namespaces are listed under `readOnlyNamespaces` in the `rune-config.yml`. Each entry is a
+[glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)) matched against a file's namespace:
+
+```yaml
+model:
+  name: My Model
+readOnlyNamespaces:
+- com.rosetta.model.*
+- cdm.base.datetime
+```
+
+In the example above, every namespace starting with `com.rosetta.model.` is read-only, as is the
+exact namespace `cdm.base.datetime`.
+
+## Adding the workflow
+
+Add a workflow to the repository (for example `.github/workflows/readonly-namespaces.yml`) that
+calls the reusable workflow on every pull request:
+
+```yaml
+name: Read-only namespaces
+
+on:
+  pull_request:
+
+jobs:
+  readonly-namespaces:
+    uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
+    with:
+      config-path: rune-config.yml
+```
+
+On each pull request the workflow maps every changed `.rosetta` file to its namespace and fails if
+a change affects a read-only namespace. Concretely, a change is rejected when a file's namespace is
+read-only **before** the change (a file may not be modified, deleted, or moved *out of* a read-only
+namespace) or **after** the change (a file may not be added to, or moved *into*, a read-only
+namespace). It also fails if a configured pattern matches no namespace at all, which catches stale
+or mistyped entries.
+
+## Making an intentional change
+
+Sometimes a read-only namespace genuinely needs to change — for example, when a project admin rolls
+out an updated import. There is no need to remove the workflow or take the namespace out of
+`readOnlyNamespaces`. Instead, the change can be accepted as a deliberate one-off by applying the
+`override-readonly-namespaces` label (or whatever is configured via the `bypass-label` input) to
+the pull request. The next run of the check sees the label, skips the namespace check, and records
+a note explaining why. Because adding a label requires write access, the decision stays visible and
+auditable in the pull request.
+
+Once the change is merged, removing the label restores the check for future pull requests.
+
+## Parameters
+
+The reusable workflow accepts the following inputs under `with:`.
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `config-path` | Yes | — | Path to the `rune-config.yml` whose `readOnlyNamespaces` list defines the read-only namespaces. |
+| `base-ref` | No | The pull request base branch, otherwise the repository's default branch | The git ref that `HEAD` is compared against to determine which files changed. |
+| `root` | No | `.` | Directory under which to scan for `.rosetta` files (both when matching read-only patterns and when reporting changes). |
+| `checker-ref` | No | `main` | The ref of `finos/rune-dsl` from which the checker script is fetched. Pin this to a tag or commit to fix the version of the check. |
+| `bypass-label` | No | `override-readonly-namespaces` | The pull request label that, when present, skips the check to allow an intentional one-off change to a read-only namespace. |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -99,6 +99,10 @@ const sidebars: SidebarsConfig = {
           type: 'doc',
           id: 'developers/contribute-to-rune',
         },
+        {
+          type: 'doc',
+          id: 'developers/read-only-namespaces',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

**PR 3 of the "link XML config to a Rune function" stack** ([design](https://app.notion.com/p/37579b2a676b80088313c0bd33df7994)). Orthogonal to the xml-config story but part of the same config overhaul. Depends on #1256, #1257 (both merged).

Lets a project mark namespaces as **read-only** — useful for namespaces that are managed externally (e.g. generated by importing an XSD or JSON schema) and so must not be hand-edited — and have CI reject manual changes to them.

- Adds `List<String> readOnlyNamespaces` to `RuneConfiguration` (empty default, getter, deserialized via the mixin). Pure data — no DSL behaviour.
- Adds a reusable workflow `verify-readonly-namespaces.yml` (`on: workflow_call`, owns its `fetch-depth: 0` checkout) and a self-contained, stdlib-only Python checker (`.github/scripts/check_readonly_namespaces.py`).
- Documents the feature under `website/docs/developers/read-only-namespaces.mdx`.

## How the check works

The read-only namespaces are read from the project's `rune-config.yml` `readOnlyNamespaces` list — a **single source of truth**, not a separate workflow input. For each changed `.rosetta` file the checker maps its namespace **before** (base ref) and **after** (HEAD) and fails if **either** is read-only:

- a file in a read-only namespace may not be modified, deleted, or moved *out* of it;
- a file may not be added to, or moved *into*, a read-only namespace.

It also fails if a configured pattern matches no namespace (stale/mistyped pattern). The namespace parser handles an optional `override namespace …` prefix.

## Making an intentional change

Adding the **`override-readonly-namespaces`** label (configurable via the `bypass-label` input) to a PR skips the check for that PR and records a notice — so an approved change can go through without removing the workflow or the namespace from `readOnlyNamespaces`. See the docs page for details.

## Caller usage

```yaml
jobs:
  readonly-namespaces:
    uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
    with:
      config-path: rune-config.yml
```

Inputs: `config-path` (required), `base-ref`, `root`, `checker-ref`, `bypass-label`.

## Stack / diff note

Stacked on the merged #1256/#1257 and targets `main`; later PRs (#1259–#1262) stack on this one. Review/merge in order.

## Testing

`RuneConfigurationTest` asserts `readOnlyNamespaces` parsing. The checker was exercised locally against an isolated git repo: `override` namespaces parse; modify/delete/move-out-of a read-only namespace → fail; add/move-into a read-only namespace → fail; edits in non-read-only namespaces → pass; stale pattern → fail; `readOnlyNamespaces` read from both block and inline YAML.