### PR TITLE
Add transform annotations with generated @Ingest/@Projection/@Enrich

### DIFF
--- a/.github/scripts/check_readonly_namespaces.py
+++ b/.github/scripts/check_readonly_namespaces.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Fail the build when a read-only Rune namespace is changed.
+
+The read-only namespaces are read from the ``readOnlyNamespaces`` list of a
+``rune-config.yml`` file, so they are configured in a single place. A change to a
+``.rosetta`` file is a violation when the file's namespace is read-only either:
+
+* **before** the change -- you may not modify, delete or move a file *out of* a
+  read-only namespace; or
+* **after** the change -- you may not add a file to, or move a file *into*, a
+  read-only namespace.
+
+The build also fails if a configured pattern matches no namespace in the
+repository, which catches stale or mistyped patterns.
+
+The checker is self-contained: it only uses the Python standard library and git.
+"""
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Matches `namespace foo.bar`, optionally preceded by the `override` keyword and optionally quoted.
+NAMESPACE_RE = re.compile(r'^\s*(?:override\s+)?namespace\s+"?([A-Za-z0-9_.]+)"?', re.MULTILINE)
+
+
+def git(*args):
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout
+
+
+def git_show(ref, path):
+    """Content of `path` at `ref`, or None if it does not exist there."""
+    result = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True)
+    return result.stdout if result.returncode == 0 else None
+
+
+def namespace_of(text):
+    if text is None:
+        return None
+    match = NAMESPACE_RE.search(text)
+    return match.group(1) if match else None
+
+
+def read_readonly_namespaces(config_path):
+    """Read the `readOnlyNamespaces` list from a rune-config.yml file."""
+    config = Path(config_path)
+    if not config.is_file():
+        return []
+    patterns = []
+    in_block = False
+    for raw in config.read_text(encoding="utf-8").splitlines():
+        line = re.sub(r'\s+#.*$', '', raw).rstrip()  # strip trailing comments
+        if not line.strip():
+            continue
+        key = re.match(r'^readOnlyNamespaces\s*:\s*(.*)$', line)
+        if key:
+            inline = key.group(1).strip()
+            if inline.startswith("["):
+                patterns.extend(_clean(v) for v in inline.strip("[]").split(",") if _clean(v))
+                in_block = False
+            else:
+                in_block = True
+            continue
+        if in_block:
+            item = re.match(r'^\s*-\s*(.+?)\s*$', line)
+            if item:
+                value = _clean(item.group(1))
+                if value:
+                    patterns.append(value)
+            elif not line[:1].isspace():
+                in_block = False  # reached the next top-level key
+    return patterns
+
+
+def _clean(value):
+    return value.strip().strip('"').strip("'")
+
+
+def changed_rosetta_files(base):
+    """Yield (status, old_path, new_path) for changed files between base and HEAD."""
+    out = git("diff", "--name-status", "-z", f"{base}...HEAD")
+    tokens = out.split("\0")
+    i = 0
+    while i < len(tokens):
+        status = tokens[i]
+        if not status:
+            i += 1
+            continue
+        code = status[0]
+        if code in ("R", "C"):
+            yield code, tokens[i + 1], tokens[i + 2]
+            i += 3
+        else:
+            yield code, tokens[i + 1], tokens[i + 1]
+            i += 2
+
+
+def matches_any(namespace, patterns):
+    return namespace is not None and any(fnmatch.fnmatchcase(namespace, pattern) for pattern in patterns)
+
+
+def repository_namespaces(root):
+    namespaces = set()
+    for file in Path(root).rglob("*.rosetta"):
+        try:
+            namespace = namespace_of(file.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        if namespace:
+            namespaces.add(namespace)
+    return namespaces
+
+
+def describe(code, old, new):
+    verb = {"A": "added", "M": "modified", "D": "deleted", "R": "renamed", "C": "copied"}.get(code, "changed")
+    return f"{new} ({verb})" if old == new else f"{old} -> {new} ({verb})"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify that read-only Rune namespaces are not changed.")
+    parser.add_argument("--base", required=True, help="Git ref to diff HEAD against.")
+    parser.add_argument("--config", required=True,
+                        help="Path to the rune-config.yml whose readOnlyNamespaces lists the read-only patterns.")
+    parser.add_argument("--root", default=".", help="Directory to scan for .rosetta files.")
+    args = parser.parse_args()
+
+    patterns = read_readonly_namespaces(args.config)
+    if not patterns:
+        print(f"No readOnlyNamespaces configured in '{args.config}'; nothing to check.")
+        return 0
+
+    failures = []
+
+    # 1. Stale-pattern check: every configured pattern must match at least one namespace.
+    all_namespaces = repository_namespaces(args.root)
+    for pattern in patterns:
+        if not any(fnmatch.fnmatchcase(ns, pattern) for ns in all_namespaces):
+            failures.append(
+                f"Read-only namespace pattern '{pattern}' does not match any .rosetta namespace "
+                f"under '{args.root}' (stale or mistyped pattern?)."
+            )
+
+    # 2. Changed-file check: a file may not be read-only before OR after the change.
+    for code, old, new in changed_rosetta_files(args.base):
+        if not (old.endswith(".rosetta") or new.endswith(".rosetta")):
+            continue
+        before = None if code in ("A", "C") else namespace_of(git_show(args.base, old))
+        after = None if code == "D" else namespace_of(read_worktree(new))
+        if matches_any(before, patterns):
+            failures.append(f"{describe(code, old, new)} changes a file in read-only namespace '{before}'.")
+        elif matches_any(after, patterns):
+            failures.append(f"{describe(code, old, new)} moves a file into read-only namespace '{after}'.")
+
+    if failures:
+        print("Read-only namespace check FAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print(f"Read-only namespace check passed ({len(patterns)} pattern(s) checked).")
+    return 0
+
+
+def read_worktree(path):
+    file = Path(path)
+    if not file.is_file():
+        return None
+    return file.read_text(encoding="utf-8", errors="replace")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-readonly-namespaces.yml
+++ b/.github/workflows/verify-readonly-namespaces.yml
@@ -1,0 +1,92 @@
+name: Verify read-only namespaces
+
+# Reusable workflow that fails when a read-only Rune namespace is
+# changed in a pull request. The read-only namespaces are read from the
+# `readOnlyNamespaces` list of the project's rune-config.yml. Call it with:
+#
+#   jobs:
+#     readonly-namespaces:
+#       uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
+#       with:
+#         config-path: rune-config.yml
+#
+on:
+  workflow_call:
+    inputs:
+      config-path:
+        description: "Path to the rune-config.yml whose readOnlyNamespaces lists the read-only namespaces."
+        required: true
+        type: string
+      base-ref:
+        description: "Git ref to diff HEAD against. Defaults to the pull request base branch, or the repository default branch."
+        required: false
+        default: ""
+        type: string
+      root:
+        description: "Directory under which to scan for .rosetta files."
+        required: false
+        default: "."
+        type: string
+      checker-ref:
+        description: "Ref of finos/rune-dsl from which to fetch the checker script."
+        required: false
+        default: "main"
+        type: string
+      bypass-label:
+        description: "Pull request label that skips the check, to allow an intentional one-off change to a read-only namespace."
+        required: false
+        default: "override-readonly-namespaces"
+        type: string
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository under test
+        uses: actions/checkout@v6
+        with:
+          # Full history so HEAD can be diffed against the base ref.
+          fetch-depth: 0
+
+      - name: Check out the read-only-namespace checker
+        uses: actions/checkout@v6
+        with:
+          repository: finos/rune-dsl
+          ref: ${{ inputs.checker-ref }}
+          path: .rune-dsl-checker
+          sparse-checkout: .github/scripts
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Resolve base ref
+        id: base
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.base-ref }}" ]; then
+            base="${{ inputs.base-ref }}"
+          elif [ -n "${{ github.base_ref }}" ]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            base="origin/${{ github.base_ref }}"
+          else
+            git fetch --no-tags origin "${{ github.event.repository.default_branch }}"
+            base="origin/${{ github.event.repository.default_branch }}"
+          fi
+          echo "ref=$base" >> "$GITHUB_OUTPUT"
+          echo "Diffing against base ref: $base"
+
+      - name: Check read-only namespaces
+        if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.bypass-label) }}
+        shell: bash
+        run: |
+          python .rune-dsl-checker/.github/scripts/check_readonly_namespaces.py \
+            --base "${{ steps.base.outputs.ref }}" \
+            --config "${{ inputs.config-path }}" \
+            --root "${{ inputs.root }}"
+
+      - name: Read-only namespace check bypassed
+        if: ${{ contains(github.event.pull_request.labels.*.name, inputs.bypass-label) }}
+        run: |
+          echo "::notice::Read-only namespace check skipped because the '${{ inputs.bypass-label }}' label is present on this pull request."

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ com.regnosys.rosetta.web/
 .vscode/
 /rosetta-ide/vscode/node_modules/
 
+# Python
+__pycache__/
+*.pyc
+
 # Docusaurus website
 website/.docusaurus
 website/build

--- a/rune-ide/rosetta.tmLanguage.yaml
+++ b/rune-ide/rosetta.tmLanguage.yaml
@@ -568,11 +568,23 @@ repository:
           1: { name: punctuation.annotation.end.rosetta }
         patterns:
         - include: '#comment'
+        - include: '#transformAnnotationBody'
         - include: '#prefixAnnotationBody'
         - include: '#referenceAnnotationBody'
         - include: '#ruleReferenceAnnotationBody'
         - include: '#labelAnnotationBody'
         - include: '#customAnnotationBody'
+
+      transformAnnotationBody:
+        name: meta.annotated.transform.rosetta
+        begin: '{{wordStart}}(ingest|enrich|projection){{wordEnd}}'
+        beginCaptures:
+          1: { name: keyword.other.transform.rosetta }
+        end: (?=\])|{{sectionEnd}}
+        patterns:
+        - include: '#comment'
+        - name: variable.other.enummember.rosetta
+          match: '{{identifier}}'
 
       prefixAnnotationBody:
         name: meta.annotated.prefix.rosetta

--- a/rune-ide/rosetta.tmLanguage.yaml
+++ b/rune-ide/rosetta.tmLanguage.yaml
@@ -29,7 +29,7 @@ variables:
   # - keywords that are unambiguous, i.e., all other keywords indicating the start of a root element.
   identifiersConflictingWithNamespace: '{{wordStart}}(scope|version){{wordEnd}}'
   ambiguousRootStart: '{{wordStart}}rule{{wordEnd}}'
-  unambiguousRootStart: '{{wordStart}}(namespace|import|isEvent|isProduct|body|corpus|segment|basicType|recordType|typeAlias|library|reporting|eligibility|metaType|report|annotation|enum|type|choice|func){{wordEnd}}'
+  unambiguousRootStart: '{{wordStart}}(namespace|import|isEvent|isProduct|body|corpus|segment|basicType|recordType|typeAlias|library|reporting|eligibility|metaType|report|annotation|enum|type|choice|func|schema){{wordEnd}}'
   rootStart: '{{ambiguousRootStart}}|{{unambiguousRootStart}}'
   namespaceEnd: (?={{identifiersConflictingWithNamespace}}|{{ambiguousRootStart}}|{{unambiguousRootStart}})
   rootEnd: (?={{ambiguousRootStart}}|{{unambiguousRootStart}})
@@ -156,6 +156,7 @@ repository:
           - include: '#typeDeclaration'
           - include: '#choiceDeclaration'
           - include: '#functionDeclaration'
+          - include: '#rosettaSchema'
 
       rosettaBody:
         name: meta.body.rosetta
@@ -850,6 +851,23 @@ repository:
       choiceOption:
         patterns:
         - include: '#typeCall'
+
+      rosettaSchema:
+        name: meta.schema.rosetta
+        begin: '{{wordStart}}schema{{wordEnd}}'
+        beginCaptures:
+          0: { name: storage.type.schema.rosetta keyword.declaration.schema.rosetta }
+        end: '{{rootEnd}}'
+        patterns:
+        - include: '#comment'
+        - begin: '{{identifier}}'
+          beginCaptures:
+            0: { name: entity.name.schema.rosetta }
+          end: '{{rootEnd}}'
+          patterns:
+          - include: '#comment'
+          - name: variable.other.enummember.rosetta
+            match: '{{identifier}}'
 
       functionDeclaration:
         name: meta.function.rosetta

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/RuneConfigurationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/RuneConfigurationTest.java
@@ -40,7 +40,8 @@ public class RuneConfigurationTest {
 		assertFalse(filter.test("foo"));
 		assertTrue(filter.test("abc.def"));
 		assertFalse(filter.test("abc.def.sub"));
-		
+
+		assertEquals(java.util.List.of("com.rosetta.model.*", "abc.def"), config.getReadOnlyNamespaces());
 	}
 	
 

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/RuneConfigurationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/RuneConfigurationTest.java
@@ -42,6 +42,13 @@ public class RuneConfigurationTest {
 		assertFalse(filter.test("abc.def.sub"));
 
 		assertEquals(java.util.List.of("com.rosetta.model.*", "abc.def"), config.getReadOnlyNamespaces());
+
+		assertEquals(2, config.getSerializationConfig().size());
+		assertEquals("xml-config/fixml-xml-config.json",
+				config.findSerializationConfigById("fixml").orElseThrow().getConfigPath());
+		assertEquals("json-config/my-json-config.json",
+				config.findSerializationConfigById("myJson").orElseThrow().getConfigPath());
+		assertFalse(config.findSerializationConfigById("doesNotExist").isPresent());
 	}
 	
 

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/TransformAnnotationGeneratorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/TransformAnnotationGeneratorTest.java
@@ -1,0 +1,74 @@
+package com.regnosys.rosetta.generator.java.function;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
+import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaTestInjectorProvider.class)
+public class TransformAnnotationGeneratorTest {
+
+	@Inject
+	private CodeGeneratorTestHelper generatorTestHelper;
+
+	@Test
+	void generatesTransformAnnotationsOnFunctionClasses() {
+		Map<String, String> code = generatorTestHelper.generateCode("""
+				namespace test
+
+				schema fixml XML
+
+				type Foo:
+					a string (1..1)
+
+				func IngestBareFormat:
+					[ingest XML]
+					inputs:
+						input string (1..1)
+					output:
+						result Foo (1..1)
+
+				func IngestSchema:
+					[ingest fixml]
+					inputs:
+						input string (1..1)
+					output:
+						result Foo (1..1)
+
+				func Project:
+					[projection JSON]
+					inputs:
+						input Foo (1..1)
+					output:
+						result string (1..1)
+
+				func Enricher:
+					[enrich]
+					inputs:
+						input Foo (1..1)
+					output:
+						result Foo (1..1)
+				""");
+
+		String all = String.join("\n", code.values());
+
+		assertTrue(all.contains("@Ingest(format = SerializationFormat.XML)"),
+				"bare-format ingest should emit @Ingest with just the format");
+		assertTrue(all.contains("@Ingest(id = \"fixml\", format = SerializationFormat.XML)"),
+				"schema-based ingest should emit @Ingest with id and the schema's format");
+		assertTrue(all.contains("@Projection(format = SerializationFormat.JSON)"),
+				"projection should emit @Projection with the format");
+		assertTrue(all.contains("@Enrich"),
+				"enrich should emit @Enrich");
+	}
+}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
@@ -70,7 +70,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                        inp Input (1..1)
                 """, """
                 WARNING (null) 'A function should specify an implementation, or they should be annotated with codeImplementation' at 10:6, length 6, on Function
-                ERROR (null) 'Transform functions must have a single input.' at 11:4, length 16, on AnnotationRef
+                ERROR (null) 'Transform functions must have a single input.' at 11:4, length 16, on TransformAnnotation
                 ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
                 """
         );
@@ -121,7 +121,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                        result string (1..1)
                 """, """
                 WARNING (null) 'A function should specify an implementation, or they should be annotated with codeImplementation' at 7:6, length 6, on Function
-                ERROR (null) 'Transform functions must have a single input.' at 8:4, length 12, on AnnotationRef
+                ERROR (null) 'Transform functions must have a single input.' at 8:4, length 12, on TransformAnnotation
                 """
         );
     }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.java
@@ -49,7 +49,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				func Foo:
 					[projection]
 				""", """
-                ERROR (null) 'The `projection` annotation must have a target format such as JSON, XML or CSV' at 5:3, length 10, on AnnotationRef
+                ERROR (null) 'The `projection` annotation must have a target format such as JSON, XML or CSV.' at 5:3, length 10, on TransformAnnotation
                 """);
     }
 
@@ -67,7 +67,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				func Foo:
 					[ingest]
 				""", """
-                ERROR (null) 'The `ingest` annotation must have a source format such as JSON, XML or CSV' at 5:3, length 6, on AnnotationRef
+                ERROR (null) 'The `ingest` annotation must have a source format such as JSON, XML or CSV.' at 5:3, length 6, on TransformAnnotation
                 """);
     }
 
@@ -78,32 +78,35 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 					[ingest JSON]
 					[enrich]
 				""", """
-                ERROR (null) 'Only one transform annotation allowed.' at 6:2, length 8, on AnnotationRef
+                ERROR (null) 'Only one transform annotation allowed.' at 6:2, length 8, on TransformAnnotation
                 """);
     }
 
     @Test
-    void testTransformAnnotationShouldBeUsedOnFunction() {
+    void testTransformAnnotationCanNotBeUsedOnNonFunction() {
+        // The transform construct ([ingest]/[enrich]/[projection]) is only valid on a function.
+        // On any other element these words parse as a (non-existent) annotation, so they are
+        // reported as unresolved annotation references.
         var model1 = modelHelper.parseRosetta("""
 				type Foo:
 					[ingest JSON]
 				""");
 
-        validationTestHelper.assertError(model1, ROSETTA_NAMED, null, "Transform annotations only allowed on a function.");
+        validationTestHelper.assertError(model1, ANNOTATION_REF, Diagnostic.LINKING_DIAGNOSTIC, "Couldn't resolve reference to Annotation 'ingest'.");
 
         var model2 = modelHelper.parseRosetta("""
 				type Foo:
 					[enrich]
 				""");
 
-        validationTestHelper.assertError(model2, ROSETTA_NAMED, null, "Transform annotations only allowed on a function.");
+        validationTestHelper.assertError(model2, ANNOTATION_REF, Diagnostic.LINKING_DIAGNOSTIC, "Couldn't resolve reference to Annotation 'enrich'.");
 
         var model3 = modelHelper.parseRosetta("""
 				type Foo:
 					[projection]
 				""");
 
-        validationTestHelper.assertError(model3, ROSETTA_NAMED, null, "Transform annotations only allowed on a function.");
+        validationTestHelper.assertError(model3, ANNOTATION_REF, Diagnostic.LINKING_DIAGNOSTIC, "Couldn't resolve reference to Annotation 'projection'.");
     }
 
     @Test

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/SchemaParsingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/SchemaParsingTest.java
@@ -1,0 +1,40 @@
+package com.regnosys.rosetta.validation;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaTestInjectorProvider.class)
+public class SchemaParsingTest extends AbstractValidatorTest {
+
+	@Test
+	void testSchemaReferencingBuiltInFormatsParses() {
+		assertNoIssues("""
+				namespace test
+				version "1"
+
+				schema fixml XML
+				schema myJson JSON
+				schema runeJson RUNE_JSON
+				schema csvSchema CSV
+				""");
+	}
+
+	@Test
+	void testDuplicateSchemaNamesAreNotAllowed() {
+		assertIssues("""
+				namespace test
+				version "1"
+
+				schema fixml XML
+				schema fixml JSON
+				""", """
+				ERROR (null) 'Duplicate schema 'fixml' in namespace 'test'' at 4:8, length 5, on Schema
+				ERROR (null) 'Duplicate schema 'fixml' in namespace 'test'' at 5:8, length 5, on Schema
+				""");
+	}
+}

--- a/rune-integration-tests/src/test/resources/rune-config-test.yml
+++ b/rune-integration-tests/src/test/resources/rune-config-test.yml
@@ -5,3 +5,6 @@ generators:
   namespaces:
   - xyz.*   # project namespace
   - abc.def # forked namespace
+readOnlyNamespaces:
+- com.rosetta.model.*
+- abc.def

--- a/rune-integration-tests/src/test/resources/rune-config-test.yml
+++ b/rune-integration-tests/src/test/resources/rune-config-test.yml
@@ -8,3 +8,8 @@ generators:
 readOnlyNamespaces:
 - com.rosetta.model.*
 - abc.def
+serializationConfig:
+- id: fixml
+  configPath: xml-config/fixml-xml-config.json
+- id: myJson
+  configPath: json-config/my-json-config.json

--- a/rune-lang/model/Rosetta.xcore
+++ b/rune-lang/model/Rosetta.xcore
@@ -137,10 +137,16 @@ class RosettaEnumeration extends RootElement, RosettaType, RosettaDefinable, Ref
 	contains RosettaEnumValue[] enumValues opposite enumeration
 }
 
-class RosettaEnumValue extends RosettaSymbol, RosettaDefinable, RosettaFeature, References, Annotated, SwitchCaseTarget {
+class RosettaEnumValue extends RosettaSymbol, RosettaDefinable, RosettaFeature, References, Annotated, SwitchCaseTarget, SchemaOrFormat {
 	String display
 	container RosettaEnumeration enumeration opposite enumValues
 }
+
+/**
+ * Marker for things a transform annotation can refer to as its (de)serialization target:
+ * either a named `Schema` or a value of the built-in `SerializationFormat` enum.
+ */
+interface SchemaOrFormat {}
 
 class RosettaEnumValueReference {
 	refers RosettaEnumeration enumeration
@@ -152,7 +158,7 @@ class RosettaEnumValueReference {
  * (de)serialization format of a transform function. The `format` refers to a value of
  * the built-in `SerializationFormat` enum.
  */
-class Schema extends RosettaRootElement, RosettaNamed {
+class Schema extends RosettaRootElement, RosettaNamed, SchemaOrFormat {
 	refers RosettaEnumValue format
 }
 

--- a/rune-lang/model/Rosetta.xcore
+++ b/rune-lang/model/Rosetta.xcore
@@ -147,6 +147,15 @@ class RosettaEnumValueReference {
 	refers RosettaEnumValue value
 }
 
+/**
+ * A named serialization schema, referenced by transform annotations to declare the
+ * (de)serialization format of a transform function. The `format` refers to a value of
+ * the built-in `SerializationFormat` enum.
+ */
+class Schema extends RosettaRootElement, RosettaNamed {
+	refers RosettaEnumValue format
+}
+
 class RosettaCardinality {
 	int inf
 	int sup

--- a/rune-lang/model/RosettaSimple.xcore
+++ b/rune-lang/model/RosettaSimple.xcore
@@ -12,6 +12,7 @@ import com.regnosys.rosetta.rosetta.RosettaDocReference
 import com.regnosys.rosetta.rosetta.RosettaEnumValueReference
 import com.regnosys.rosetta.rosetta.RosettaNamed
 import com.regnosys.rosetta.rosetta.RosettaRootElement
+import com.regnosys.rosetta.rosetta.SchemaOrFormat
 import com.regnosys.rosetta.rosetta.RosettaTypeWithConditions
 import com.regnosys.rosetta.rosetta.RosettaTypedFeature
 import com.regnosys.rosetta.rosetta.RosettaRule
@@ -52,6 +53,21 @@ class AnnotationRef {
 	refers Annotation ^annotation
 	refers Attribute attribute
 	contains AnnotationQualifier[] qualifiers
+}
+
+enum TransformKind {
+	ingest
+	enrich
+	projection
+}
+
+/*
+ * A transform annotation on a function, e.g. `[ingest fixml]`, `[projection XML]` or `[enrich]`.
+ * `ref` (absent for `enrich`) points at a `Schema` or a `SerializationFormat` value.
+ */
+class TransformAnnotation {
+	TransformKind kind
+	refers SchemaOrFormat ref
 }
 
 interface BuiltinAnnotation extends RosettaNamed {
@@ -155,6 +171,7 @@ class ChoiceOption extends Attribute, SwitchCaseTarget {
 
 class Function extends RootElement, RosettaNamed, RosettaCallableWithArgs, References {
 	refers Function superFunction
+	contains TransformAnnotation[] transform
 	contains Attribute[] inputs
 	contains Attribute output
 	contains ShortcutDeclaration[] shortcuts opposite function

--- a/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
@@ -102,7 +102,7 @@ Function:
 	)
 	('extends' superFunction=[Function|QualifiedName])?
 	':' RosettaDefinable?
-	(References|Annotations)*
+	(transform+=TransformAnnotation|References|Annotations)*
 	('inputs' ':' inputs += Attribute+)?
 	('output' ':' output = Attribute)?
 	
@@ -174,6 +174,14 @@ Schema:
 	'schema' RosettaNamed format=[RosettaEnumValue|ValidID]
 ;
 
+enum TransformKind:
+	ingest | enrich | projection
+;
+
+TransformAnnotation:
+	'[' kind=TransformKind (ref=[SchemaOrFormat|ValidID])? ']'
+;
+
 
 
 /**********************************************************************
@@ -213,7 +221,7 @@ TypeParameterValidID:
 ;
 
 ValidID:
-	ID | 'condition' | 'source' | 'version' | 'scope'
+	ID | 'condition' | 'source' | 'version' | 'scope' | 'ingest' | 'enrich' | 'projection'
 ;
 
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
@@ -167,6 +167,11 @@ RosettaRootElement:
 	| Data
 	| Choice
 	| Function
+	| Schema
+;
+
+Schema:
+	'schema' RosettaNamed format=[RosettaEnumValue|ValidID]
 ;
 
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
@@ -34,6 +34,13 @@ import com.regnosys.rosetta.rosetta.simple.Condition
 import com.regnosys.rosetta.rosetta.simple.Function
 import com.regnosys.rosetta.rosetta.simple.FunctionDispatch
 import com.regnosys.rosetta.rosetta.simple.ShortcutDeclaration
+import com.regnosys.rosetta.rosetta.simple.TransformAnnotation
+import com.regnosys.rosetta.rosetta.simple.TransformKind
+import com.regnosys.rosetta.utils.TransformAnnotationHelper
+import com.rosetta.model.lib.transform.Ingest
+import com.rosetta.model.lib.transform.Projection
+import com.rosetta.model.lib.transform.Enrich
+import com.rosetta.model.lib.transform.SerializationFormat
 import com.regnosys.rosetta.types.CardinalityProvider
 import com.regnosys.rosetta.types.RAttribute
 import com.regnosys.rosetta.types.RChoiceType
@@ -102,6 +109,7 @@ class FunctionGenerator extends RObjectJavaClassGenerator<RFunction, RGeneratedJ
 	@Inject extension ModelIdProvider
 	@Inject LabelProviderGeneratorUtil labelProviderUtil
 	@Inject AliasUtil aliasUtil
+	@Inject TransformAnnotationHelper transformAnnotationHelper
 	
 	override protected streamObjects(RosettaModel model) {
 		model.elements.stream.filter[it instanceof Function && !(it instanceof FunctionDispatch)].map[it as Function].map[rTypeBuilderFactory.buildRFunction(it)]
@@ -125,6 +133,9 @@ class FunctionGenerator extends RObjectJavaClassGenerator<RFunction, RGeneratedJ
 				val labelProviderClass = rFunction.toLabelProviderJavaClass
 				annotations.put(RuneLabelProvider, '''labelProvider=«labelProviderClass».class''' )
 			}
+			if (origin instanceof Function && !(origin as Function).transform.empty) {
+				addTransformAnnotation((origin as Function).transform.head, annotations)
+			}
 			rBuildClass(rFunction, javaFunctionClass, false, functionInterfaces, annotations, overridesEvaluate, scope)
 		}
 	}
@@ -134,6 +145,21 @@ class FunctionGenerator extends RObjectJavaClassGenerator<RFunction, RGeneratedJ
 		rFunction.classBody(javaFunctionClass, isStatic, overridesEvaluate, dependencies, functionInterfaces, annotations, classScope)
 	}
 	
+	private def void addTransformAnnotation(TransformAnnotation transform, Map<Class<?>, StringConcatenationClient> annotations) {
+		if (transform.kind === TransformKind.ENRICH) {
+			annotations.put(Enrich, '''''')
+			return
+		}
+		val format = transformAnnotationHelper.getFormat(transform).orElse(null)
+		if (format === null) {
+			return // an ingest/projection without a resolvable format is reported by validation
+		}
+		val id = transformAnnotationHelper.getSchemaId(transform).orElse(null)
+		val configPath = transformAnnotationHelper.getConfigPath(transform).orElse(null)
+		val StringConcatenationClient attributes = '''«IF id !== null»id = "«id»", «ENDIF»format = «SerializationFormat».«format»«IF configPath !== null», configPath = "«configPath»"«ENDIF»'''
+		annotations.put(if (transform.kind === TransformKind.INGEST) Ingest else Projection, attributes)
+	}
+
 	private def getQualifyingFunctionInterface(List<RAttribute> inputs) {
 		val parameterVariable = inputs.head.RMetaAnnotatedType.toListOrSingleJavaType(inputs.head.multi)
 		JavaParameterizedType.from(new TypeReference<IQualifyFunctionExtension<?>>() {}, parameterVariable)

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/function/LabelProviderGeneratorUtil.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/function/LabelProviderGeneratorUtil.java
@@ -1,15 +1,10 @@
 package com.regnosys.rosetta.generator.java.function;
 
-import jakarta.inject.Inject;
-
-import com.regnosys.rosetta.generator.util.RosettaFunctionExtensions;
 import com.regnosys.rosetta.rosetta.simple.Function;
 
 public class LabelProviderGeneratorUtil {
-	@Inject
-	private RosettaFunctionExtensions funcExtensions;
-	
+
 	public boolean shouldGenerateLabelProvider(Function function) {
-		return !funcExtensions.getTransformAnnotations(function).isEmpty();
+		return !function.getTransform().isEmpty();
 	}
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/types/JavaTypeTranslator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/types/JavaTypeTranslator.java
@@ -309,7 +309,16 @@ public class JavaTypeTranslator extends RosettaTypeSwitch<JavaType, Void> {
 		return javaType;
 	}
 	private JavaType toJavaType(RType type) {
+		// The built-in SerializationFormat enum (declared in basictypes.rosetta) is not generated;
+		// it maps onto the canonical hand-written enum com.rosetta.model.lib.transform.SerializationFormat.
+		if (type instanceof REnumType && isBuiltInSerializationFormat((REnumType) type)) {
+			return typeUtil.SERIALIZATION_FORMAT;
+		}
 		return doSwitch(type, null);
+	}
+	private boolean isBuiltInSerializationFormat(REnumType type) {
+		return "SerializationFormat".equals(type.getName())
+				&& DottedPath.splitOnDots("com.rosetta.model").equals(type.getNamespace());
 	}
 	public JavaPojoInterface toJavaType(RDataType type) {
 		return caseDataType(type, null);

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/types/JavaTypeUtil.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/types/JavaTypeUtil.java
@@ -74,6 +74,7 @@ public class JavaTypeUtil {
 	public final JavaClass<com.rosetta.model.lib.records.Date> DATE = JavaClass.from(com.rosetta.model.lib.records.Date.class);
 	public final JavaClass<LocalDateTime> LOCAL_DATE_TIME = JavaClass.from(LocalDateTime.class);
 	public final JavaClass<ZonedDateTime> ZONED_DATE_TIME = JavaClass.from(ZonedDateTime.class);
+	public final JavaClass<com.rosetta.model.lib.transform.SerializationFormat> SERIALIZATION_FORMAT = JavaClass.from(com.rosetta.model.lib.transform.SerializationFormat.class);
 	
 	public final JavaClass<GlobalKey> GLOBAL_KEY = JavaClass.from(GlobalKey.class);
 	public final JavaClass<GlobalKey.GlobalKeyBuilder> GLOBAL_KEY_BUILDER = JavaClass.from(GlobalKey.GlobalKeyBuilder.class);

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/util/RosettaFunctionExtensions.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/util/RosettaFunctionExtensions.java
@@ -2,7 +2,6 @@ package com.regnosys.rosetta.generator.util;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.regnosys.rosetta.rosetta.RosettaModel;
 import org.eclipse.xtext.EcoreUtil2;
@@ -136,23 +135,6 @@ public class RosettaFunctionExtensions {
             return List.of();
         }
 		return annotations.stream().filter(it -> "qualification".equals(it.getAnnotation().getName())).toList();
-	}
-	
-	public List<AnnotationRef> getTransformAnnotations(Annotated element) {
-        if(element.getAnnotations() == null || element.getAnnotations().isEmpty()) {
-            return List.of();
-        }
-		return element.getAnnotations().stream()
-			.filter(ecoreUtil::isResolved)
-			.filter(it -> {
-                RosettaModel model = it.getAnnotation().getModel();
-                if (model == null) {
-                    return false;
-                }
-                return "com.rosetta.model".equals(model.getName());
-            })
-			.filter(it -> Stream.of("ingest", "enrich", "projection").anyMatch(transformName -> transformName.equals(it.getAnnotation().getName())))
-			.toList();
 	}
 	
 	public List<AnnotationRef> getCreationAnnotations(Annotated element) {

--- a/rune-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.java
@@ -109,14 +109,10 @@ public class RosettaScopeProvider extends ImportedNamespaceAwareLocalScopeProvid
 				}
 			} else if (reference.equals(SCHEMA__FORMAT)) {
 				// A schema's format refers to a value of the built-in SerializationFormat enum.
-				RosettaModel basicTypes = builtinsService.getBasicTypesModel(context.eResource().getResourceSet());
-				return basicTypes.getElements().stream()
-						.filter(RosettaEnumeration.class::isInstance)
-						.map(RosettaEnumeration.class::cast)
-						.filter(e -> "SerializationFormat".equals(e.getName()))
-						.findFirst()
-						.map(e -> (IScope) Scopes.scopeFor(e.getEnumValues()))
-						.orElse(IScope.NULLSCOPE);
+				return Scopes.scopeFor(serializationFormatValues(context));
+			} else if (reference.equals(TRANSFORM_ANNOTATION__REF)) {
+				// A transform annotation's ref is either a SerializationFormat value or a named Schema.
+				return Scopes.scopeFor(serializationFormatValues(context), super.getScope(context, reference));
 			} else if (reference.equals(ROSETTA_FEATURE_CALL__FEATURE)) {
 				if (context instanceof RosettaFeatureCall featureCall) {
 					return createExtendedFeatureScope(featureCall.getReceiver(), typeProvider.getRMetaAnnotatedType(featureCall.getReceiver()));
@@ -370,6 +366,16 @@ public class RosettaScopeProvider extends ImportedNamespaceAwareLocalScopeProvid
 
 	private IScope defaultScope(EObject object, EReference reference) {
 		return super.getScope(object, reference);
+	}
+
+	private Iterable<? extends EObject> serializationFormatValues(EObject context) {
+		RosettaModel basicTypes = builtinsService.getBasicTypesModel(context.eResource().getResourceSet());
+		for (var element : basicTypes.getElements()) {
+			if (element instanceof RosettaEnumeration e && "SerializationFormat".equals(e.getName())) {
+				return e.getEnumValues();
+			}
+		}
+		return java.util.Collections.emptyList();
 	}
 	
 	@Override

--- a/rune-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.java
@@ -107,6 +107,16 @@ public class RosettaScopeProvider extends ImportedNamespaceAwareLocalScopeProvid
 					}
 					return IScope.NULLSCOPE;
 				}
+			} else if (reference.equals(SCHEMA__FORMAT)) {
+				// A schema's format refers to a value of the built-in SerializationFormat enum.
+				RosettaModel basicTypes = builtinsService.getBasicTypesModel(context.eResource().getResourceSet());
+				return basicTypes.getElements().stream()
+						.filter(RosettaEnumeration.class::isInstance)
+						.map(RosettaEnumeration.class::cast)
+						.filter(e -> "SerializationFormat".equals(e.getName()))
+						.findFirst()
+						.map(e -> (IScope) Scopes.scopeFor(e.getEnumValues()))
+						.orElse(IScope.NULLSCOPE);
 			} else if (reference.equals(ROSETTA_FEATURE_CALL__FEATURE)) {
 				if (context instanceof RosettaFeatureCall featureCall) {
 					return createExtendedFeatureScope(featureCall.getReceiver(), typeProvider.getRMetaAnnotatedType(featureCall.getReceiver()));

--- a/rune-lang/src/main/java/com/regnosys/rosetta/utils/TransformAnnotationHelper.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/utils/TransformAnnotationHelper.java
@@ -1,0 +1,62 @@
+package com.regnosys.rosetta.utils;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.regnosys.rosetta.config.RuneConfiguration;
+import com.regnosys.rosetta.rosetta.RosettaEnumValue;
+import com.regnosys.rosetta.rosetta.Schema;
+import com.regnosys.rosetta.rosetta.SchemaOrFormat;
+import com.regnosys.rosetta.rosetta.simple.Function;
+import com.regnosys.rosetta.rosetta.simple.TransformAnnotation;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * Resolves a function's transform annotation ({@code [ingest ...]}, {@code [projection ...]} or
+ * {@code [enrich]}) to its serialization details: the optional schema id, the serialization format,
+ * and the optional config file path (looked up by schema id in the Rune configuration).
+ */
+@Singleton
+public class TransformAnnotationHelper {
+	@Inject
+	private RuneConfiguration config;
+
+	public List<TransformAnnotation> getTransformAnnotations(Function function) {
+		return function.getTransform();
+	}
+
+	public Optional<TransformAnnotation> getTransformAnnotation(Function function) {
+		return function.getTransform().stream().findFirst();
+	}
+
+	/** The schema id, i.e. the name of the referenced {@code schema}; empty for a bare format. */
+	public Optional<String> getSchemaId(TransformAnnotation annotation) {
+		SchemaOrFormat ref = annotation.getRef();
+		return ref instanceof Schema schema ? Optional.ofNullable(schema.getName()) : Optional.empty();
+	}
+
+	/** The resolved serialization format name (e.g. {@code XML}); empty for {@code enrich} or an unresolved ref. */
+	public Optional<String> getFormat(TransformAnnotation annotation) {
+		SchemaOrFormat ref = annotation.getRef();
+		if (ref instanceof RosettaEnumValue formatValue) {
+			return Optional.ofNullable(formatValue.getName());
+		}
+		if (ref instanceof Schema schema && schema.getFormat() != null) {
+			return Optional.ofNullable(schema.getFormat().getName());
+		}
+		return Optional.empty();
+	}
+
+	public boolean hasFormat(TransformAnnotation annotation, String formatName) {
+		return getFormat(annotation).map(formatName::equals).orElse(false);
+	}
+
+	/** The classpath location of the schema's config file, looked up by id in the Rune configuration. */
+	public Optional<String> getConfigPath(TransformAnnotation annotation) {
+		return getSchemaId(annotation)
+				.flatMap(config::findSerializationConfigById)
+				.map(c -> c.getConfigPath());
+	}
+}

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/FunctionValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/FunctionValidator.java
@@ -8,6 +8,7 @@ import com.regnosys.rosetta.types.RDataType;
 import com.regnosys.rosetta.types.RObjectFactory;
 import com.regnosys.rosetta.types.RType;
 import com.regnosys.rosetta.utils.CsvUtil;
+import com.regnosys.rosetta.utils.TransformAnnotationHelper;
 import jakarta.inject.Inject;
 import org.eclipse.xtext.validation.Check;
 import static com.regnosys.rosetta.rosetta.RosettaPackage.Literals.*;
@@ -26,6 +27,8 @@ public class FunctionValidator extends AbstractDeclarativeRosettaValidator {
     private RObjectFactory rObjectFactory;
     @Inject
     private WarningSuppressionHelper warningSuppressionHelper;
+    @Inject
+    private TransformAnnotationHelper transformAnnotationHelper;
 
     @Check
     public void checkFunctionNameStartsWithCapital(Function func) {
@@ -37,7 +40,7 @@ public class FunctionValidator extends AbstractDeclarativeRosettaValidator {
     
     @Check
     public void checkCsvIngestionInput(Function function) {
-        if (hasCsvTransformAnnotation(function, "ingest")) {
+        if (hasCsvTransformAnnotation(function, TransformKind.INGEST)) {
             if (!function.getInputs().isEmpty()) {
                 checkAttributeIsTabular(function.getInputs().get(0), "The input of a CSV ingest function");
             }
@@ -45,7 +48,7 @@ public class FunctionValidator extends AbstractDeclarativeRosettaValidator {
     }
     @Check
     public void checkCsvProjectionOutput(Function function) {
-        if (hasCsvTransformAnnotation(function, "projection")) {
+        if (hasCsvTransformAnnotation(function, TransformKind.PROJECTION)) {
             Attribute output = function.getOutput();
             if (output != null) {
                 checkAttributeIsTabular(output, "The output of a CSV projection function");
@@ -68,12 +71,11 @@ public class FunctionValidator extends AbstractDeclarativeRosettaValidator {
             error(attributeDescription + " must be single cardinality", attribute, SimplePackage.Literals.ATTRIBUTE__CARD);
         }
     }
-    private boolean hasCsvTransformAnnotation(Function function, String transformName) {
-        return functionExtensions.getTransformAnnotations(function)
-                .stream()
-                .filter(a -> a.getAttribute() != null && "CSV".equals(a.getAttribute().getName()))
-                .map(AnnotationRef::getAnnotation)
-                .anyMatch(a -> a != null && transformName.equals(a.getName()));
+    private boolean hasCsvTransformAnnotation(Function function, TransformKind kind) {
+        return transformAnnotationHelper.getTransformAnnotation(function)
+                .filter(a -> a.getKind() == kind)
+                .map(a -> transformAnnotationHelper.hasFormat(a, "CSV"))
+                .orElse(false);
     }
     
     @Check

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/RosettaSimpleValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/RosettaSimpleValidator.java
@@ -616,41 +616,34 @@ public class RosettaSimpleValidator extends AbstractDeclarativeRosettaValidator 
     }
 
     @Check
-    public void checkTransformAnnotations(Annotated ele) {
-        List<AnnotationRef> annotations = rosettaFunctionExtensions.getTransformAnnotations(ele);
+    public void checkTransformAnnotations(Function func) {
+        List<TransformAnnotation> annotations = func.getTransform();
         if (annotations.isEmpty()) return;
 
-        if (!(ele instanceof Function func)) {
-            error("Transform annotations only allowed on a function.", RosettaPackage.Literals.ROSETTA_NAMED__NAME);
-            return;
-        }
         if (annotations.size() > 1) {
             // Keep first, error on the rest
             annotations.stream().skip(1).forEach(it ->
                     error("Only one transform annotation allowed.", it, null)
             );
         }
-        AnnotationRef annotationRef = annotations.get(0);
+        TransformAnnotation annotation = annotations.get(0);
         // A transformation may only have a single input
         func.getInputs().stream().skip(1)
                 .forEach(i -> error("Transform functions may only have a single input.", i, null));
-        if (func.getOutput() != null) {
-            if (func.getInputs().isEmpty()) {
-                error("Transform functions must have a single input.", annotationRef, null);
-            }
+        if (func.getOutput() != null && func.getInputs().isEmpty()) {
+            error("Transform functions must have a single input.", annotation, null);
         }
-        String name = annotationRef.getAnnotation().getName();
-        if (Objects.equals(name, "ingest")) {
-            if (annotationRef.getAttribute() == null) {
-                error("The `ingest` annotation must have a source format such as JSON, XML or CSV",
-                        annotationRef, SimplePackage.Literals.ANNOTATION_REF__ANNOTATION);
+        TransformKind kind = annotation.getKind();
+        if (kind == TransformKind.ENRICH) {
+            if (annotation.getRef() != null) {
+                error("The `enrich` annotation must not reference a schema or format.",
+                        annotation, SimplePackage.Literals.TRANSFORM_ANNOTATION__REF);
             }
-        }
-        if (Objects.equals(name, "projection")) {
-            if (annotationRef.getAttribute() == null) {
-                error("The `projection` annotation must have a target format such as JSON, XML or CSV",
-                        annotationRef, SimplePackage.Literals.ANNOTATION_REF__ANNOTATION);
-            }
+        } else if (annotation.getRef() == null) {
+            String direction = kind == TransformKind.INGEST ? "source" : "target";
+            error("The `" + kind.getLiteral() + "` annotation must have a " + direction
+                    + " format such as JSON, XML or CSV.",
+                    annotation, SimplePackage.Literals.TRANSFORM_ANNOTATION__KIND);
         }
     }
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaNamesAreUniqueValidationHelper.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaNamesAreUniqueValidationHelper.java
@@ -46,6 +46,7 @@ public class RosettaNamesAreUniqueValidationHelper extends NamesAreUniqueValidat
             .put(RosettaPackage.eINSTANCE.getRosettaCorpus(), "corpus")
             .put(RosettaPackage.eINSTANCE.getRosettaSegment(), "segment")
             .put(RosettaPackage.eINSTANCE.getRosettaScope(), "scope")
+            .put(RosettaPackage.eINSTANCE.getSchema(), "schema")
             .put(SimplePackage.eINSTANCE.getAttribute(), "attribute")
             .build();
     

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaUniqueNamesConfig.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaUniqueNamesConfig.java
@@ -54,6 +54,10 @@ public class RosettaUniqueNamesConfig {
         
         // Check scopes have a unique name
         addGlobalCheck(RosettaPackage.eINSTANCE.getRosettaScope(), false);
+
+        // Check serialisation schemas have a unique name. A schema does not generate a file,
+        // so case-sensitive uniqueness is sufficient.
+        addGlobalCheck(RosettaPackage.eINSTANCE.getSchema(), true);
         
         // Check attributes in data have a unique name
         addLocalCheck(SimplePackage.eINSTANCE.getAttribute(), Attribute.class, this::getDirectDataContainer, Data::getAttributes, true);

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneConfiguration.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneConfiguration.java
@@ -1,5 +1,6 @@
 package com.regnosys.rosetta.config;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -7,17 +8,27 @@ public class RuneConfiguration {
 	private final RuneModelConfiguration model;
 	private final List<RuneDependencyConfiguration> dependencies;
 	private final RuneGeneratorsConfiguration generators;
-	
-	public RuneConfiguration(RuneModelConfiguration model, 
+	private final List<String> readOnlyNamespaces;
+
+	public RuneConfiguration(RuneModelConfiguration model,
 			List<RuneDependencyConfiguration> dependencies,
 			RuneGeneratorsConfiguration generators) {
+		this(model, dependencies, generators, Collections.emptyList());
+	}
+
+	public RuneConfiguration(RuneModelConfiguration model,
+			List<RuneDependencyConfiguration> dependencies,
+			RuneGeneratorsConfiguration generators,
+			List<String> readOnlyNamespaces) {
 		Objects.requireNonNull(model);
 		Objects.requireNonNull(dependencies);
 		Objects.requireNonNull(generators);
-		
+		Objects.requireNonNull(readOnlyNamespaces);
+
 		this.model = model;
 		this.dependencies = dependencies;
 		this.generators = generators;
+		this.readOnlyNamespaces = readOnlyNamespaces;
 	}
 
 	public RuneModelConfiguration getModel() {
@@ -30,5 +41,9 @@ public class RuneConfiguration {
 
 	public RuneGeneratorsConfiguration getGenerators() {
 		return generators;
+	}
+
+	public List<String> getReadOnlyNamespaces() {
+		return readOnlyNamespaces;
 	}
 }

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneConfiguration.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneConfiguration.java
@@ -3,32 +3,37 @@ package com.regnosys.rosetta.config;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class RuneConfiguration {
 	private final RuneModelConfiguration model;
 	private final List<RuneDependencyConfiguration> dependencies;
 	private final RuneGeneratorsConfiguration generators;
 	private final List<String> readOnlyNamespaces;
+	private final List<RuneSerializationConfiguration> serializationConfig;
 
 	public RuneConfiguration(RuneModelConfiguration model,
 			List<RuneDependencyConfiguration> dependencies,
 			RuneGeneratorsConfiguration generators) {
-		this(model, dependencies, generators, Collections.emptyList());
+		this(model, dependencies, generators, Collections.emptyList(), Collections.emptyList());
 	}
 
 	public RuneConfiguration(RuneModelConfiguration model,
 			List<RuneDependencyConfiguration> dependencies,
 			RuneGeneratorsConfiguration generators,
-			List<String> readOnlyNamespaces) {
+			List<String> readOnlyNamespaces,
+			List<RuneSerializationConfiguration> serializationConfig) {
 		Objects.requireNonNull(model);
 		Objects.requireNonNull(dependencies);
 		Objects.requireNonNull(generators);
 		Objects.requireNonNull(readOnlyNamespaces);
+		Objects.requireNonNull(serializationConfig);
 
 		this.model = model;
 		this.dependencies = dependencies;
 		this.generators = generators;
 		this.readOnlyNamespaces = readOnlyNamespaces;
+		this.serializationConfig = serializationConfig;
 	}
 
 	public RuneModelConfiguration getModel() {
@@ -45,5 +50,18 @@ public class RuneConfiguration {
 
 	public List<String> getReadOnlyNamespaces() {
 		return readOnlyNamespaces;
+	}
+
+	public List<RuneSerializationConfiguration> getSerializationConfig() {
+		return serializationConfig;
+	}
+
+	/**
+	 * Finds the serialization configuration with the given schema id, if any.
+	 */
+	public Optional<RuneSerializationConfiguration> findSerializationConfigById(String id) {
+		return serializationConfig.stream()
+				.filter(c -> c.getId().equals(id))
+				.findFirst();
 	}
 }

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneSerializationConfiguration.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneSerializationConfiguration.java
@@ -1,0 +1,26 @@
+package com.regnosys.rosetta.config;
+
+import java.util.Objects;
+
+/**
+ * Maps a serialization schema id (the name of a {@code schema} declaration) onto the
+ * classpath location of its configuration file (e.g. an XML config).
+ */
+public class RuneSerializationConfiguration {
+	private final String id;
+	private final String configPath;
+
+	public RuneSerializationConfiguration(String id, String configPath) {
+		Objects.requireNonNull(id);
+		this.id = id;
+		this.configPath = configPath;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getConfigPath() {
+		return configPath;
+	}
+}

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/FileBasedRuneConfigurationProvider.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/FileBasedRuneConfigurationProvider.java
@@ -19,6 +19,7 @@ import com.regnosys.rosetta.config.DefaultRuneConfigurationProvider;
 import com.regnosys.rosetta.config.RuneConfiguration;
 import com.regnosys.rosetta.config.RuneGeneratorsConfiguration;
 import com.regnosys.rosetta.config.RuneModelConfiguration;
+import com.regnosys.rosetta.config.RuneSerializationConfiguration;
 
 public class FileBasedRuneConfigurationProvider implements Provider<RuneConfiguration> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedRuneConfigurationProvider.class);
@@ -34,7 +35,8 @@ public class FileBasedRuneConfigurationProvider implements Provider<RuneConfigur
 		this.mapper = new ObjectMapper(new YAMLFactory())
 				.addMixIn(RuneConfiguration.class, RuneConfigurationMixin.class)
 				.addMixIn(RuneModelConfiguration.class, RuneModelConfigurationMixin.class)
-				.addMixIn(RuneGeneratorsConfiguration.class, RuneGeneratorsConfigurationMixin.class);
+				.addMixIn(RuneGeneratorsConfiguration.class, RuneGeneratorsConfigurationMixin.class)
+				.addMixIn(RuneSerializationConfiguration.class, RuneSerializationConfigurationMixin.class);
 		mapper.configOverride(RuneGeneratorsConfiguration.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY));
         mapper.configOverride(NamespaceFilter.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY));
 		mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY));

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationMixin.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationMixin.java
@@ -13,5 +13,6 @@ public abstract class RuneConfigurationMixin {
 	public RuneConfigurationMixin(
 			@JsonProperty("model") RuneModelConfiguration model,
 			@JsonProperty("dependencies") List<RuneDependencyConfiguration> dependencies,
-			@JsonProperty("generators") RuneGeneratorsConfiguration generators) {}
+			@JsonProperty("generators") RuneGeneratorsConfiguration generators,
+			@JsonProperty("readOnlyNamespaces") List<String> readOnlyNamespaces) {}
 }

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationMixin.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationMixin.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.regnosys.rosetta.config.RuneDependencyConfiguration;
 import com.regnosys.rosetta.config.RuneGeneratorsConfiguration;
 import com.regnosys.rosetta.config.RuneModelConfiguration;
+import com.regnosys.rosetta.config.RuneSerializationConfiguration;
 
 public abstract class RuneConfigurationMixin {
 	@JsonCreator
@@ -14,5 +15,6 @@ public abstract class RuneConfigurationMixin {
 			@JsonProperty("model") RuneModelConfiguration model,
 			@JsonProperty("dependencies") List<RuneDependencyConfiguration> dependencies,
 			@JsonProperty("generators") RuneGeneratorsConfiguration generators,
-			@JsonProperty("readOnlyNamespaces") List<String> readOnlyNamespaces) {}
+			@JsonProperty("readOnlyNamespaces") List<String> readOnlyNamespaces,
+			@JsonProperty("serializationConfig") List<RuneSerializationConfiguration> serializationConfig) {}
 }

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneSerializationConfigurationMixin.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneSerializationConfigurationMixin.java
@@ -1,0 +1,11 @@
+package com.regnosys.rosetta.config.file;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class RuneSerializationConfigurationMixin {
+	@JsonCreator
+	public RuneSerializationConfigurationMixin(
+			@JsonProperty("id") String id,
+			@JsonProperty("configPath") String configPath) {}
+}

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/transform/Enrich.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/transform/Enrich.java
@@ -1,0 +1,15 @@
+package com.rosetta.model.lib.transform;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a generated function class as performing an enrichment. Unlike ingestion and projection,
+ * an enrichment does not (de)serialize, so it carries no format or configuration.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Enrich {
+}

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/transform/Ingest.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/transform/Ingest.java
@@ -1,0 +1,23 @@
+package com.rosetta.model.lib.transform;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a generated function class as performing an ingestion, declaring the inbound
+ * (de)serialization format and, optionally, the schema id and config file that configure it.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Ingest {
+    /** The schema id (the name of the referenced {@code schema}), or empty for a bare format. */
+    String id() default "";
+
+    /** The inbound serialization format. */
+    SerializationFormat format();
+
+    /** The classpath location of the format's configuration file, or empty if there is none. */
+    String configPath() default "";
+}

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/transform/Projection.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/transform/Projection.java
@@ -1,0 +1,23 @@
+package com.rosetta.model.lib.transform;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a generated function class as performing a projection, declaring the outbound
+ * (de)serialization format and, optionally, the schema id and config file that configure it.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Projection {
+    /** The schema id (the name of the referenced {@code schema}), or empty for a bare format. */
+    String id() default "";
+
+    /** The outbound serialization format. */
+    SerializationFormat format();
+
+    /** The classpath location of the format's configuration file, or empty if there is none. */
+    String configPath() default "";
+}

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/transform/SerializationFormat.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/transform/SerializationFormat.java
@@ -1,0 +1,21 @@
+package com.rosetta.model.lib.transform;
+
+/**
+ * The wire format used to (de)serialize the input or output of a transform function
+ * (e.g. an ingestion or projection).
+ * <p>
+ * This is the canonical Java representation of the {@code SerializationFormat} enum declared
+ * in {@code basictypes.rosetta}: the Rune code generator maps the model enum onto this type
+ * rather than generating a duplicate, so there is a single shared enum across the DSL, the
+ * generated annotations and the runtime.
+ */
+public enum SerializationFormat {
+    /** Plain JSON, mapping directly onto the structure of the Rune type. */
+    JSON,
+    /** The Rune-specific JSON representation, which preserves Rune metadata such as references and scheme information. */
+    RUNE_JSON,
+    /** XML, typically configured by an associated XML configuration file that maps the schema onto the Rune type. */
+    XML,
+    /** Comma-separated values. Only valid for tabular types, i.e. types whose attributes are all single-cardinality basic types. */
+    CSV
+}

--- a/rune-runtime/src/main/resources/model/annotations.rosetta
+++ b/rune-runtime/src/main/resources/model/annotations.rosetta
@@ -20,20 +20,6 @@ annotation qualification: <"Annotation that describes a func that is used for ev
 
 annotation deprecated: <"Marks a type, function or enum as deprecated and will be removed/replaced.">
 
-annotation ingest: <"Marks a function that performs ingestion operations with the in bound serialisation format">
-	JSON boolean (0..1)
-	RUNE_JSON boolean (0..1)
-	XML boolean (0..1)
-	CSV boolean (0..1)
-
-annotation enrich: <"Marks a function that performs enrichment operations">
-	
-annotation projection: <"Marks a function that performs projection operations with the out bound serialisation format">
-	JSON boolean (0..1)
-	RUNE_JSON boolean (0..1)
-	XML boolean (0..1)
-	CSV boolean (0..1)
-	
 annotation codeImplementation: <"Marks the function as statically implemented by model internal code, with no body defined in Rune.">
 
 annotation suppressWarnings:

--- a/rune-runtime/src/main/resources/model/basictypes.rosetta
+++ b/rune-runtime/src/main/resources/model/basictypes.rosetta
@@ -52,3 +52,10 @@ recordType zonedDateTime
 
 typeAlias calculation:
 	string
+
+enum SerializationFormat: <"The wire format used to (de)serialize the input or output of a transform function (e.g. an ingestion or projection).">
+	JSON <"Plain JSON, mapping directly onto the structure of the Rune type.">
+	RUNE_JSON <"The Rune-specific JSON representation, which preserves Rune metadata such as references and scheme information.">
+	XML <"XML, typically configured by an associated XML configuration file that maps the schema onto the Rune type.">
+	CSV <"Comma-separated values. Only valid for tabular types, i.e. types whose attributes are all single-cardinality basic types.">
+

--- a/website/docs/developers/read-only-namespaces.mdx
+++ b/website/docs/developers/read-only-namespaces.mdx
@@ -1,0 +1,84 @@
+---
+title: Read-only namespaces
+sidebar_label: Read-only namespaces
+description: "Use the read-only namespaces GitHub workflow to prevent manual changes to namespaces that are managed externally."
+slug: /developers/read-only-namespaces
+---
+
+# Read-only namespaces
+
+Some namespaces in a model are not authored by hand: they are generated from an external schema —
+for example, a namespace produced by importing an XSD or a JSON schema. The generated Rune is a
+faithful representation of that schema, so editing those files manually would make the model drift
+away from the schema it is meant to mirror, silently breaking the correspondence between them.
+
+To prevent that, such namespaces can be marked as **read-only**. They are listed in the
+`rune-config.yml`, and a supplied GitHub workflow then fails any pull request that hand-edits a
+read-only namespace — until someone deliberately decides to allow it. Nothing is locked forever;
+the check is a safety net that turns an accidental manual edit into a conscious decision (and the
+right way to update a read-only namespace is to re-run the import that generated it).
+
+## Declaring the read-only namespaces
+
+Read-only namespaces are listed under `readOnlyNamespaces` in the `rune-config.yml`. Each entry is a
+[glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)) matched against a file's namespace:
+
+```yaml
+model:
+  name: My Model
+readOnlyNamespaces:
+- com.rosetta.model.*
+- cdm.base.datetime
+```
+
+In the example above, every namespace starting with `com.rosetta.model.` is read-only, as is the
+exact namespace `cdm.base.datetime`.
+
+## Adding the workflow
+
+Add a workflow to the repository (for example `.github/workflows/readonly-namespaces.yml`) that
+calls the reusable workflow on every pull request:
+
+```yaml
+name: Read-only namespaces
+
+on:
+  pull_request:
+
+jobs:
+  readonly-namespaces:
+    uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
+    with:
+      config-path: rune-config.yml
+```
+
+On each pull request the workflow maps every changed `.rosetta` file to its namespace and fails if
+a change affects a read-only namespace. Concretely, a change is rejected when a file's namespace is
+read-only **before** the change (a file may not be modified, deleted, or moved *out of* a read-only
+namespace) or **after** the change (a file may not be added to, or moved *into*, a read-only
+namespace). It also fails if a configured pattern matches no namespace at all, which catches stale
+or mistyped entries.
+
+## Making an intentional change
+
+Sometimes a read-only namespace genuinely needs to change — for example, when a project admin rolls
+out an updated import. There is no need to remove the workflow or take the namespace out of
+`readOnlyNamespaces`. Instead, the change can be accepted as a deliberate one-off by applying the
+`override-readonly-namespaces` label (or whatever is configured via the `bypass-label` input) to
+the pull request. The next run of the check sees the label, skips the namespace check, and records
+a note explaining why. Because adding a label requires write access, the decision stays visible and
+auditable in the pull request.
+
+Once the change is merged, removing the label restores the check for future pull requests.
+
+## Parameters
+
+The reusable workflow accepts the following inputs under `with:`.
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `config-path` | Yes | — | Path to the `rune-config.yml` whose `readOnlyNamespaces` list defines the read-only namespaces. |
+| `base-ref` | No | The pull request base branch, otherwise the repository's default branch | The git ref that `HEAD` is compared against to determine which files changed. |
+| `root` | No | `.` | Directory under which to scan for `.rosetta` files (both when matching read-only patterns and when reporting changes). |
+| `checker-ref` | No | `main` | The ref of `finos/rune-dsl` from which the checker script is fetched. Pin this to a tag or commit to fix the version of the check. |
+| `bypass-label` | No | `override-readonly-namespaces` | The pull request label that, when present, skips the check to allow an intentional one-off change to a read-only namespace. |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -99,6 +99,10 @@ const sidebars: SidebarsConfig = {
           type: 'doc',
           id: 'developers/contribute-to-rune',
         },
+        {
+          type: 'doc',
+          id: 'developers/read-only-namespaces',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

**PR 5 of the "link XML config to a Rune function" stack** ([design](https://app.notion.com/p/37579b2a676b80088313c0bd33df7994)) — the core of the story. Depends on #1256–#1259.

Replaces the `ingest`/`enrich`/`projection` annotations (generic annotations with boolean format attributes) with a dedicated construct, and makes the generator bake the transform's serialization details into a runtime annotation.

## What's new

- **`TransformKind`** enum + **`TransformAnnotation`** — `[ingest <fmt-or-schema>]`, `[projection <fmt-or-schema>]`, `[enrich]`. `ref` resolves to a `Schema` **or** a `SerializationFormat` value via a new **`SchemaOrFormat`** marker interface (implemented by both `Schema` and `RosettaEnumValue`), scoped in `RosettaScopeProvider`. Transform annotations are **order-independent** with the function's other annotations.
- **`ingest`/`enrich`/`projection` added to `ValidID`** (contextual keywords) so existing models using these words as identifiers (e.g. FpML's `projection` attribute) keep parsing.
- The old transform annotation declarations are **removed** from `annotations.rosetta`.
- **`TransformAnnotationHelper`** resolves a transform annotation to `{schema id?, format, configPath?}` (configPath looked up by id in the Rune config).
- **Validation** migrated: exactly one transform annotation per function; single input; `enrich` must not reference a schema/format; `ingest`/`projection` require a format; CSV-must-be-tabular keys off the resolved format.
- **`FunctionGenerator`** emits `@Ingest(id?, format, configPath?)` / `@Projection(...)` / `@Enrich` (new runtime annotations in `com.rosetta.model.lib.transform`) on the generated function class.

`[ingest XML]` / `[projection XML]` / `[enrich]` remain backward compatible.

## Stack / diff note

Stacked on #1256–#1259 and targets `main`, so the diff currently includes the earlier PRs; it shrinks once they merge. Review/merge in order.

## Testing

New `TransformAnnotationGeneratorTest` (asserts the emitted `@Ingest`/`@Projection`/`@Enrich`, bare-format and schema-based); updated `FunctionValidatorTest`/`RosettaValidatorTest`; formatter, serializer, parser and function/enum-generator regression subsets all pass.