### PR TITLE
Indent schema annotations and rename maven-plugin runeConfig parameter

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
@@ -129,6 +129,39 @@ public class RosettaFormattingTest {
 	}
 
 	@Test
+	void testFormatSchemaWithAnnotationOnIndentedLine() {
+		formatAndAssert("""
+				namespace test
+				version "1"
+
+
+				schema   fixml   XML   [deprecated]
+				""", """
+				namespace test
+				version "1"
+
+				schema fixml XML
+					[deprecated]
+				""");
+	}
+
+	@Test
+	void testFormatSchemaWithoutAnnotation() {
+		formatAndAssert("""
+				namespace test
+				version "1"
+
+
+				schema   fixml    XML
+				""", """
+				namespace test
+				version "1"
+
+				schema fixml XML
+				""");
+	}
+
+	@Test
 	void testFormatTypeAliasWithDocumentation() {
 		formatAndAssert("""
 				namespace test

--- a/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
@@ -36,6 +36,7 @@ import com.regnosys.rosetta.rosetta.RosettaRootElement;
 import com.regnosys.rosetta.rosetta.RosettaRule;
 import com.regnosys.rosetta.rosetta.RosettaScope;
 import com.regnosys.rosetta.rosetta.RosettaSegment;
+import com.regnosys.rosetta.rosetta.Schema;
 import com.regnosys.rosetta.rosetta.RosettaTypeAlias;
 import com.regnosys.rosetta.rosetta.TypeCall;
 import com.regnosys.rosetta.rosetta.TypeCallArgument;
@@ -211,6 +212,20 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 	private void format(TypeParameter ele, IFormattableDocument document) {
 		document.format(document.prepend(ele.getTypeCall(), IHiddenRegionFormatter::oneSpace));
 		formatDefinition(ele, document);
+	}
+
+	private void format(Schema ele, IFormattableDocument document) {
+		document.append(regionFor(ele).keyword(grammarAccess.getSchemaAccess().getSchemaKeyword_0()),
+				IHiddenRegionFormatter::oneSpace);
+		document.prepend(regionFor(ele).feature(RosettaPackage.Literals.ROSETTA_NAMED__NAME),
+				IHiddenRegionFormatter::oneSpace);
+		document.prepend(regionFor(ele).assignment(grammarAccess.getSchemaAccess().getFormatAssignment_2()),
+				IHiddenRegionFormatter::oneSpace);
+		formattingUtil.indentInner(ele, document);
+		ele.getAnnotations().forEach(ann -> {
+			document.prepend(ann, IHiddenRegionFormatter::newLine);
+			document.format(ann);
+		});
 	}
 
 	private void format(RosettaExternalFunction ele, IFormattableDocument document) {

--- a/rune-maven-plugin/src/main/java/com/regnosys/rosetta/maven/AbstractRuneGeneratorMojo.java
+++ b/rune-maven-plugin/src/main/java/com/regnosys/rosetta/maven/AbstractRuneGeneratorMojo.java
@@ -59,6 +59,18 @@ public abstract class AbstractRuneGeneratorMojo extends AbstractXtextGeneratorMo
     @Parameter
     private String classPathLookupFilter;
 
+    /**
+     * Path to the Rune configuration file.
+     */
+    @Parameter
+    private String runeConfig;
+
+    /**
+     * @deprecated Use {@code runeConfig} instead. This parameter is kept for backwards
+     * compatibility and will be removed in a future release. If both are set, {@code runeConfig}
+     * takes precedence.
+     */
+    @Deprecated
     @Parameter
     private String rosettaConfig;
 
@@ -111,6 +123,25 @@ public abstract class AbstractRuneGeneratorMojo extends AbstractXtextGeneratorMo
         return new RuneMavenStandaloneBuilderModule();
     }
 
+    /**
+     * Resolves the configuration file path, preferring the {@code runeConfig} parameter and
+     * falling back to the deprecated {@code rosettaConfig} parameter for backwards compatibility.
+     */
+    private String resolveConfig() {
+        if (runeConfig != null) {
+            if (rosettaConfig != null) {
+                getLog().warn("Both 'runeConfig' and the deprecated 'rosettaConfig' parameters are set; "
+                        + "using 'runeConfig' and ignoring 'rosettaConfig'.");
+            }
+            return runeConfig;
+        }
+        if (rosettaConfig != null) {
+            getLog().warn("The 'rosettaConfig' parameter is deprecated; use 'runeConfig' instead.");
+            return rosettaConfig;
+        }
+        return null;
+    }
+
     @Override
     public MavenProject getProject() {
         return project;
@@ -131,8 +162,9 @@ public abstract class AbstractRuneGeneratorMojo extends AbstractXtextGeneratorMo
         // This saves time and memory during the build.
         language.setJavaSupport(false);
 
+        String resolvedConfig = resolveConfig();
         Map<String, LanguageAccess> languages = new RuneLanguageAccessFactory()
-                .createLanguageAccess(language, rosettaConfig, this.getClass().getClassLoader(), createClasspathClassLoader());
+                .createLanguageAccess(language, resolvedConfig, this.getClass().getClassLoader(), createClasspathClassLoader());
         Injector injector = Guice.createInjector(createModule());
         RuneStandaloneBuilder builder = injector.getInstance(RuneStandaloneBuilder.class);
         builder.setBaseDir(getProject().getBasedir().getAbsolutePath());


### PR DESCRIPTION
This PR bundles two small, independent improvements.

## 1. Formatter: schema annotations on their own indented line
Previously a `schema` declaration with an annotation formatted everything on one line:
```
schema fixml XML [externalConfig]
```
It now formats annotations like `type`/`func` annotations — on the next line, indented:
```
schema fixml XML
	[externalConfig]
```
Implemented by adding a `format(Schema ...)` method to `RosettaFormatter` (the formatter previously had no `Schema`-specific handler, so the model fell through to the generic dispatch and never applied the newline+indent treatment). The `schema NAME FORMAT` header stays on one line; each annotation is prepended with a newline and indented via `indentInner`, mirroring `format(Data ...)`. Added two formatter tests (`testFormatSchemaWithAnnotationOnIndentedLine`, `testFormatSchemaWithoutAnnotation`).

## 2. rune-maven-plugin: rename `<rosettaConfig>` to `<runeConfig>`
The mojo parameter pointing at the Rune configuration file is renamed from `rosettaConfig` to `runeConfig`. The old `rosettaConfig` parameter is kept for **backwards compatibility** — it is marked `@Deprecated`, still works, and logs a deprecation warning when used. If both are set, `runeConfig` takes precedence (and a warning is logged that `rosettaConfig` is ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
