### PR TITLE
Navigate to the exact choice option in `as`/`switch`

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/AsOperationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/AsOperationTest.java
@@ -256,6 +256,72 @@ public class AsOperationTest {
         assertTrue(result);
     }
 
+    private JavaTestModel siblingSupertypeAcrossBranchesModel() {
+        // `Bar` is reachable both directly (via Inner1) and as a subtype of `Foo` (via Inner2). The extra
+        // options `A`/`B` make `Inner1` and `Inner2` incomparable subtype-wise, so the path finder cannot
+        // lean on "most specific" to disambiguate and must navigate to the exact requested option.
+        return modelService.toJavaTestModel("""
+                namespace test
+
+                type Foo:
+
+                type Bar extends Foo:
+                    barAttr int (0..1)
+
+                type Qux extends Foo:
+                    quxAttr int (0..1)
+
+                type A:
+
+                type B:
+
+                choice Outer:
+                    Inner1
+                    Inner2
+
+                choice Inner1:
+                    Bar
+                    A
+
+                choice Inner2:
+                    Foo
+                    B
+                """).compile();
+    }
+
+    @Test
+    void asNavigatesToExactOptionWhenSiblingBranchesAreIncomparable() {
+        JavaTestModel model = siblingSupertypeAcrossBranchesModel();
+        // Value is stored under Inner1.Bar -> `as Bar` must navigate to the exact Inner1.Bar option and
+        // yield that Bar. Picking the sibling supertype branch (Inner2.Foo) instead would wrongly return null.
+        Integer result = model.evaluateExpression(Integer.class, """
+                Outer { Inner1: Inner1 { Bar: Bar { barAttr: 1 }, ... }, ... } as Bar -> barAttr
+                """);
+        assertEquals(1, result);
+    }
+
+    @Test
+    void asToOptionInUnselectedBranchIsAbsentAndDoesNotThrow() {
+        JavaTestModel model = siblingSupertypeAcrossBranchesModel();
+        // Value is a Qux stored under Inner2.Foo -> `as Bar` navigates to the (absent) Inner1.Bar option,
+        // so the result is absent and no ClassCastException is thrown.
+        Boolean result = model.evaluateExpression(Boolean.class, """
+                Outer { Inner2: Inner2 { Foo: Qux { quxAttr: 2 }, ... }, ... } as Bar is absent
+                """);
+        assertTrue(result);
+    }
+
+    @Test
+    void asDoesNotMatchSubtypeStoredUnderSiblingSupertypeOption() {
+        JavaTestModel model = siblingSupertypeAcrossBranchesModel();
+        // A Bar stored under the Inner2.Foo slot lives in a different option than Inner1.Bar, so `as Bar`
+        // (which navigates to the exact Inner1.Bar option) yields absent.
+        Boolean result = model.evaluateExpression(Boolean.class, """
+                Outer { Inner2: Inner2 { Foo: Bar { barAttr: 3 }, ... }, ... } as Bar is absent
+                """);
+        assertTrue(result);
+    }
+
     @Test
     void asNestedChoiceOptionTest() {
         JavaTestModel model = modelService.toJavaTestModel("""

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/ExpressionGenerator.xtend
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/ExpressionGenerator.xtend
@@ -1209,20 +1209,12 @@ class ExpressionGenerator extends RosettaExpressionSwitch<JavaStatementBuilder, 
 	 */
 	private def JavaStatementBuilder navigateToChoiceOption(JavaStatementBuilder choiceArg, RChoiceType choiceType, RChoiceOption goal, Context context) {
 		val goalRType = goal.type.RType.stripFromTypeAliases
+		// The path ends on the option whose type is exactly `goalRType`, so the navigated value is already of
+		// the requested type - no downcast is needed.
 		val optionPath = findChoiceOptionPath(choiceType, goalRType)
-		val navigated = optionPath.fold(choiceArg, [acc, opt|
+		optionPath.fold(choiceArg, [acc, opt|
 			acc.attributeCall(opt.choiceType.withNoMeta, (opt.EObject as ChoiceOption).buildRAttribute, false, context.expectedType, context.scope)
 		])
-		// The option we navigated to may be a strict supertype of the requested option - e.g. when the
-		// requested option extends a sibling option, or is reachable only via such a sibling. In that case the
-		// runtime value is not guaranteed to be an instance of the requested option, so narrow safely with an
-		// `instanceof` guard rather than letting an external coercion emit a hard cast that throws at runtime.
-		val navigatedRType = optionPath.get(optionPath.size - 1).type.RType.stripFromTypeAliases
-		if (goalRType.equals(navigatedRType)) {
-			navigated
-		} else {
-			narrowToSubtype(navigated, goalRType.toJavaReferenceType, !navigated.expressionType.isMapperS, context)
-		}
 	}
 	private def JavaStatementBuilder narrowToSubtype(JavaStatementBuilder mapperCode, JavaType targetType, boolean isMulti, Context context) {
 		val filterScope = context.scope.lambdaScope

--- a/rune-lang/src/main/java/com/regnosys/rosetta/types/TypeSystem.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/types/TypeSystem.java
@@ -346,34 +346,42 @@ public class TypeSystem {
 	}
 	
 	/**
-	 * Find the path of choice options leading from the given choice type to the option whose type is the
-	 * closest supertype of {@code target}, descending into nested choice types as needed. The returned
-	 * list starts at an option of {@code from} and ends at the matched option.
+	 * Find the path of choice options leading from the given choice type to the option whose type is exactly
+	 * {@code target}, descending into nested choice types as needed. The returned list starts at an option of
+	 * {@code from} and ends at the option whose type equals {@code target}.
 	 *
-	 * {@code target} must be a subtype of {@code from}.
+	 * {@code target} must be the type of one of the (possibly nested) options of {@code from} - which is what
+	 * the scope provider guarantees for the `as` and `switch` operators. Because the path always ends on an
+	 * exact match, navigating it never requires an unsafe downcast: a supertype option (e.g. one whose type
+	 * is a supertype of a sibling option's type) is never selected in place of the requested option.
 	 */
 	public List<RChoiceOption> findChoiceOptionPath(RChoiceType from, RType target) {
-		List<RChoiceOption> result = new ArrayList<>();
-		RChoiceType currentChoice = from;
-		while (true) {
-			RChoiceType choiceToSearch = currentChoice;
-			// Among the options whose type is a supertype of `target`, pick the most specific one (an exact
-			// match wins). Otherwise, when an option's type is a supertype of a sibling option's type, the
-			// less specific option could be selected, producing a navigation to the wrong option attribute
-			// followed by an unsafe downcast.
-			RChoiceOption option = choiceToSearch.getOwnOptions().stream()
-					.filter(o -> isSubtypeOf(target, o.getType().getRType(), false))
-					.reduce((a, b) -> isSubtypeOf(a.getType().getRType(), b.getType().getRType(), false) ? a : b)
-					.orElseThrow(() -> new IllegalStateException(
-							"Did not find an option of " + choiceToSearch + " that is a supertype of " + target));
-			result.add(option);
+		List<RChoiceOption> path = findChoiceOptionPath(from, target, new ArrayList<>());
+		if (path == null) {
+			throw new IllegalStateException(
+					"Did not find an option of " + from + " whose type is " + target);
+		}
+		return path;
+	}
+	private List<RChoiceOption> findChoiceOptionPath(RChoiceType from, RType target, List<RChoiceOption> prefix) {
+		for (RChoiceOption option : from.getOwnOptions()) {
 			RType optionType = stripFromTypeAliases(option.getType().getRType());
-			if (optionType instanceof RChoiceType && !target.equals(optionType)) {
-				currentChoice = (RChoiceType) optionType;
-			} else {
+			if (target.equals(optionType)) {
+				List<RChoiceOption> result = new ArrayList<>(prefix);
+				result.add(option);
 				return result;
 			}
+			// Only descend into an option whose (nested) choice could contain the target.
+			if (optionType instanceof RChoiceType && isSubtypeOf(target, optionType, false)) {
+				List<RChoiceOption> extendedPrefix = new ArrayList<>(prefix);
+				extendedPrefix.add(option);
+				List<RChoiceOption> result = findChoiceOptionPath((RChoiceType) optionType, target, extendedPrefix);
+				if (result != null) {
+					return result;
+				}
+			}
 		}
+		return null;
 	}
 
 	public AliasHierarchy computeAliasHierarchy(RType t) {


### PR DESCRIPTION
Follow-up to #1295.

### Background

#1295 fixed an `as`-on-choice cast exception with two changes:
1. `TypeSystem.findChoiceOptionPath` was changed to pick the most specific supertype option via `reduce`.
2. `ExpressionGenerator.navigateToChoiceOption` gained a safe `instanceof` downcast for the case where the navigated option is a strict supertype of the requested one.

Both turn out to be unsound, as raised in review.

### Problem

When two sibling options of a choice are **incomparable** subtype-wise, `reduce` cannot order them and may navigate down the wrong branch (a sibling whose type is merely a supertype of the target). The requested option is then never reached, and `x as Opt` returns `null` even though the value is stored in its exact `Opt` slot.

Minimal reproduction:

```
choice Outer:
    Inner1
    Inner2

choice Inner1:
    Bar
    A

choice Inner2:
    Foo
    B

type Bar extends Foo: ...
```

`Outer { Inner1: Inner1 { Bar: Bar { barAttr: 1 }, ... }, ... } as Bar` wrongly yields `null` instead of the `Bar`, because the extra options `A`/`B` make `Inner1` and `Inner2` incomparable and `reduce` falls through to `Inner2` (`Foo`).

The downcast in (2) is also dead code: the scope provider only ever offers real (nested) choice options as `as`/`switch` targets, so the requested option always exists exactly and navigation never lands on a strict supertype.

### Fix

- Replace the greedy "closest supertype + `reduce`" walk in `findChoiceOptionPath` with a depth-first search (with backtracking) that finds the path to the option whose type is **exactly** the target.
- Remove the now-unreachable downcast branch in `navigateToChoiceOption`. (`narrowToSubtype` is retained — it is still used by the data-type `as` path.)

### Tests

Added three tests to `AsOperationTest` covering incomparable sibling branches. Full suite green: `AsOperationTest` 14/14, `SwitchOperationTest` 11/11 (shares `navigateToChoiceOption`), plus the type-system and expression regression suites.