### PR TITLE
Fail the read-only workflow on a missing config and point [externalConfig] errors at the annotation

### DIFF
--- a/.github/scripts/check_readonly_namespaces.py
+++ b/.github/scripts/check_readonly_namespaces.py
@@ -16,7 +16,8 @@ adds a read-only namespace and its generated files in one pull request -- is all
   flips the read-only flag either way is treated as a deliberate lock/unlock and allowed.
 
 The build also fails if a configured (head) pattern matches no namespace in the
-repository, which catches stale or mistyped patterns.
+repository, which catches stale or mistyped patterns, and if the config file does not
+exist in the working tree, which catches a mistyped config path.
 
 The checker is self-contained: it only uses the Python standard library and git.
 """
@@ -46,14 +47,6 @@ def namespace_of(text):
         return None
     match = NAMESPACE_RE.search(text)
     return match.group(1) if match else None
-
-
-def read_readonly_namespaces(config_path):
-    """Read-only namespaces from a rune-config.yml file on disk (empty list if it is absent)."""
-    config = Path(config_path)
-    if not config.is_file():
-        return []
-    return parse_readonly_namespaces(config.read_text(encoding="utf-8"))
 
 
 def parse_readonly_namespaces(text):
@@ -203,7 +196,14 @@ def main():
 
     # Read the read-only namespaces from both the head config (the checked-out worktree) and the base
     # config (read from the base ref), so added/deleted/modified files can be judged against the right one.
-    head_patterns = read_readonly_namespaces(args.config)
+    head_config = read_worktree(args.config)
+    if head_config is None:
+        # A missing config would otherwise silently disable the check, hiding a mistyped config-path
+        # (or a config that was deleted or renamed without updating the workflow).
+        print("Read-only namespace check FAILED:")
+        print(f"  - Config file '{args.config}' does not exist in the working tree. Is the config-path correct?")
+        return 1
+    head_patterns = parse_readonly_namespaces(head_config)
     base_patterns = parse_readonly_namespaces(git_show(args.base, args.config))
     if not head_patterns and not base_patterns:
         print(f"No read-only namespaces configured in '{args.config}' (base or head); nothing to check.")

--- a/.github/workflows/verify-readonly-namespaces.yml
+++ b/.github/workflows/verify-readonly-namespaces.yml
@@ -10,6 +10,8 @@ name: Verify read-only namespaces
 #       with:
 #         config-path: rune-config.yml
 #
+# For more info, see https://rune-docs.netlify.app/developers/read-only-namespaces
+#
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/verify-readonly-namespaces.yml
+++ b/.github/workflows/verify-readonly-namespaces.yml
@@ -8,7 +8,8 @@ name: Verify read-only namespaces
 #     readonly-namespaces:
 #       uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
 #       with:
-#         config-path: rune-config.yml
+#         config-path: rosetta-source/src/main/resources/rune-config.yml
+#         root: rosetta-source/src/main/rosetta
 #
 # For more info, see https://rune-docs.netlify.app/developers/read-only-namespaces
 #

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/SchemaValidationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/SchemaValidationTest.java
@@ -57,7 +57,7 @@ public class SchemaValidationTest extends AbstractValidatorTest {
 
 	@Test
 	void testExternalConfigWithoutConfigurationIsAnError() {
-		// 'myXmlSchema' has no external serialization configuration configured.
+		// 'myXmlSchema' has no external serialization configuration configured; the error points at the annotation.
 		assertIssues("""
 				namespace test
 				version "1"
@@ -65,7 +65,7 @@ public class SchemaValidationTest extends AbstractValidatorTest {
 				schema myXmlSchema XML
 					[externalConfig]
 				""", """
-				ERROR (null) 'Schema 'myXmlSchema' is marked [externalConfig] but no external serialization configuration is configured for it' at 4:8, length 11, on Schema
+				ERROR (null) 'Schema 'myXmlSchema' is marked [externalConfig] but no external serialization configuration is configured for it' at 5:3, length 14, on AnnotationRef
 				""");
 	}
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/utils/TransformAnnotationHelper.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/utils/TransformAnnotationHelper.java
@@ -78,8 +78,13 @@ public class TransformAnnotationHelper {
 
 	/** Whether the schema declares the {@code [externalConfig]} annotation. */
 	public boolean isExternalConfig(Schema schema) {
+		return findExternalConfigAnnotation(schema).isPresent();
+	}
+
+	/** The schema's {@code [externalConfig]} annotation, if it declares one. */
+	public Optional<AnnotationRef> findExternalConfigAnnotation(Schema schema) {
 		return schema.getAnnotations().stream()
-				.map(AnnotationRef::getAnnotation)
-				.anyMatch(a -> a != null && "externalConfig".equals(a.getName()));
+				.filter(a -> a.getAnnotation() != null && "externalConfig".equals(a.getAnnotation().getName()))
+				.findFirst();
 	}
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/SchemaValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/SchemaValidator.java
@@ -43,14 +43,14 @@ public class SchemaValidator extends AbstractDeclarativeRosettaValidator {
      */
     @Check
     public void checkExternalConfigMatchesConfiguration(Schema schema) {
-        boolean external = transformAnnotationHelper.isExternalConfig(schema);
+        Optional<AnnotationRef> externalAnnotation = transformAnnotationHelper.findExternalConfigAnnotation(schema);
         Optional<RuneSchemaConfiguration> configEntry = Optional.ofNullable(schema.getName())
                 .flatMap(config::findSchemaConfig)
                 .filter(c -> c.getConfigPath() != null);
-        if (external && configEntry.isEmpty()) {
+        if (externalAnnotation.isPresent() && configEntry.isEmpty()) {
             error("Schema '" + schema.getName() + "' is marked [externalConfig] but no external serialization configuration is configured for it",
-                    schema, RosettaPackage.Literals.ROSETTA_NAMED__NAME);
-        } else if (!external && configEntry.isPresent()) {
+                    externalAnnotation.get(), SimplePackage.Literals.ANNOTATION_REF__ANNOTATION);
+        } else if (externalAnnotation.isEmpty() && configEntry.isPresent()) {
             warning("An external serialization configuration is configured for schema '" + schema.getName()
                             + "', but the schema is not marked [externalConfig], so it will be ignored",
                     schema, RosettaPackage.Literals.ROSETTA_NAMED__NAME);

--- a/website/docs/developers/read-only-namespaces.mdx
+++ b/website/docs/developers/read-only-namespaces.mdx
@@ -57,8 +57,14 @@ jobs:
   readonly-namespaces:
     uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
     with:
-      config-path: rune-config.yml
+      config-path: rosetta-source/src/main/resources/rune-config.yml
+      root: rosetta-source/src/main/rosetta
 ```
+
+`config-path` is the repository path of the `rune-config.yml`; the check fails if no file exists
+there, so a mistyped path cannot silently disable the protection. `root` is optional and defaults to
+the whole repository — pointing it at the folder holding the model's `.rosetta` sources keeps
+samples, test fixtures and build output from being mistaken for model namespaces.
 
 On each pull request the workflow maps every changed `.rosetta` file to its namespace and fails if a
 change hand-edits a read-only namespace. The changes a schema import makes when it adds or removes a
@@ -83,8 +89,8 @@ The reusable workflow accepts the following inputs under `with:`.
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `config-path` | Yes | — | Path to the `rune-config.yml` whose `namespaceConfig` entries marked `readOnly: true` define the read-only namespaces. |
+| `config-path` | Yes | — | Path to the `rune-config.yml` whose `namespaceConfig` entries marked `readOnly: true` define the read-only namespaces. The check fails if no file exists at this path. |
 | `base-ref` | No | The pull request base branch, otherwise the repository's default branch | The git ref that `HEAD` is compared against to determine which files changed. |
-| `root` | No | `.` | Directory under which to scan for `.rosetta` files (both when matching read-only patterns and when reporting changes). |
+| `root` | No | `.` | Directory scanned for the model's `.rosetta` files when verifying that every read-only pattern still matches a namespace. Changed files are checked repository-wide regardless. |
 | `checker-ref` | No | `main` | The ref of `finos/rune-dsl` from which the checker script is fetched. Pin this to a tag or commit to fix the version of the check. |
 | `bypass-label` | No | `override-readonly-namespaces` | The pull request label that, when present, skips the check to allow an intentional one-off change to a read-only namespace. |


### PR DESCRIPTION
Two small follow-ups to the read-only-namespaces / schema work:

**Read-only workflow fails loudly on a wrong `config-path`.** `check_readonly_namespaces.py` previously treated a missing config file as "no read-only namespaces configured" and passed — so a mistyped `config-path` (or a config deleted/renamed without updating the caller workflow) silently disabled the protection. It now fails when the config does not exist in the working tree, in the PR that introduces the problem. (Found in the wild: the demo repo's workflow pointed at a repo-root config that never existed, and the check happily passed.) The reusable workflow's header comment now also links to the [read-only namespaces docs](https://rune-docs.netlify.app/developers/read-only-namespaces).

**`[externalConfig]` validation error placement.** The "marked `[externalConfig]` but no external serialization configuration" error is now reported on the `[externalConfig]` annotation itself rather than on the schema name, which is where the problem actually is.

Verified: script unit tests pass, plus an end-to-end check in a scratch git repo (missing path → clear failure; present config → unchanged behaviour); `SchemaValidationTest` 7/7 green with the updated error location.