### PR TITLE
Bump jackson, undici and linkify-it to patch high-severity CVEs

### DIFF
--- a/.github/actions/normalize-branch-name/package-lock.json
+++ b/.github/actions/normalize-branch-name/package-lock.json
@@ -57,9 +57,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.25.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-            "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.25</logback.version>
         <InMemoryJavaCompiler.version>1.3.0</InMemoryJavaCompiler.version>
-        <jackson.version>2.17.1</jackson.version>
+        <jackson.version>2.18.8</jackson.version>
         <guice.version>6.0.0</guice.version>
 
         <!-- test -->

--- a/rune-ide/vscode/package-lock.json
+++ b/rune-ide/vscode/package-lock.json
@@ -2414,9 +2414,19 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -4006,9 +4016,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
The CVE scanning (OWASP dependency-check) workflow started failing because several CVEs with a CVSS score >= 7 were published against dependencies already present on this branch since the last scan. This bumps them to patched versions.

| Dependency | From | To | Advisory (CVSS) |
|---|---|---|---|
| `jackson-databind` (BOM) | 2.17.1 | **2.18.8** | CVE-2026-54512 / CVE-2026-54513 (8.1) — PTV bypass. No 2.17.x fix exists, so the jackson BOM moves to 2.18.8. |
| `undici` (rune-ide/vscode) | 7.24.8 | **7.28.0** | CVE-2026-6734 (8.8) + WebSocket fragment-count DoS advisories |
| `undici` (.github/actions/normalize-branch-name) | 6.23.x | **6.27.0** | same advisories (6.x patch line) |
| `linkify-it` (rune-ide/vscode) | 5.0.0 | **5.0.2** | GHSA-22p9-wv53-3rq4 / CVE-2026-48801 (quadratic `match` DoS) |

The npm dependencies are transitive; only their resolved versions in the lock files change (the existing semver ranges already permit the fixes). Full `mvn clean install` passes with the jackson 2.18 bump (integration-tests 1487 / runtime 89 — 0 failures).

A companion PR (#1318) applies the same bumps to `9.x.x`.
