### PR TITLE
Fix NPE when reading an attribute overridden to zero cardinality (#1321)

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/object/RosettaObjectInheritanceGeneratorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/object/RosettaObjectInheritanceGeneratorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -16,8 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
-import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper;
-import com.regnosys.rosetta.tests.util.ModelHelper;
+import com.regnosys.rosetta.tests.testmodel.JavaTestModel;
+import com.regnosys.rosetta.tests.testmodel.RosettaTestModelService;
 import com.rosetta.model.lib.RosettaModelObjectBuilder;
 
 @ExtendWith(InjectionExtension.class)
@@ -25,13 +24,11 @@ import com.rosetta.model.lib.RosettaModelObjectBuilder;
 class RosettaObjectInheritanceGeneratorTest {
 
 	@Inject
-	private CodeGeneratorTestHelper generatorTestHelper;
-	@Inject
-	private ModelHelper modelHelper;
+	private RosettaTestModelService testModelService;
 
 	@Test
 	void shouldGenerateJavaClassWithMultipleParents() {
-		Map<String, String> generated = generatorTestHelper.generateCode("""
+		JavaTestModel model = testModelService.toJavaTestModel("""
 				type A:
 					aa string (0..1)
 
@@ -43,15 +40,12 @@ class RosettaObjectInheritanceGeneratorTest {
 
 				type D extends C:
 					dd string (0..1)
+				""").compile();
 
-				""");
-
-		Map<String, Class<?>> classes = generatorTestHelper.compileToClasses(generated);
-
-		Class<?> classA = classes.get(modelHelper.rootPackage() + ".A");
-		Class<?> classB = classes.get(modelHelper.rootPackage() + ".B");
-		Class<?> classC = classes.get(modelHelper.rootPackage() + ".C");
-		Class<?> classD = classes.get(modelHelper.rootPackage() + ".D");
+		Class<?> classA = model.getTypeJavaClass("A");
+		Class<?> classB = model.getTypeJavaClass("B");
+		Class<?> classC = model.getTypeJavaClass("C");
+		Class<?> classD = model.getTypeJavaClass("D");
 
 		assertTrue(classC.isAssignableFrom(classD));
 		assertTrue(classB.isAssignableFrom(classC));
@@ -61,17 +55,9 @@ class RosettaObjectInheritanceGeneratorTest {
 	@Disabled // override is deprecated
 	@Test
 	void shouldGenerateJavaClassWithOverridenAttributesAcrossNamespaces() {
-		// The two model files are passed in reverse order: this test only works if
-		// the order of the "files" is the opposite from that provided.
-		Map<String, String> generated = generatorTestHelper.generateCode("""
-				namespace "original"
-
-				type A:
-					aa string (0..1)
-
-				type Top:
-					aField A (0..1)
-				""", """
+		// The extending model is passed as the primary source, so that `getTypeJavaClass`
+		// resolves `Top` to `extending.Top`.
+		JavaTestModel model = testModelService.toJavaTestModel("""
 				namespace "extending"
 
 				import original.*
@@ -81,26 +67,26 @@ class RosettaObjectInheritanceGeneratorTest {
 
 				type Top extends original.Top:
 					override aField A (0..1)
-				""");
+				""", """
+				namespace "original"
 
-		Map<String, Class<?>> classes = generatorTestHelper.compileToClasses(generated);
-		Class<?> extendingTop = classes.get("extending.Top");
+				type A:
+					aa string (0..1)
+
+				type Top:
+					aField A (0..1)
+				""").compile();
+
+		Class<?> extendingTop = model.getTypeJavaClass("Top");
 		assertThrows(NoSuchFieldException.class, () -> extendingTop.getDeclaredField("aField"));
 	}
 
 	@Disabled // override is deprecated
 	@Test
 	void shouldGenerateJavaClassWithOverridenListAttributesAcrossNamespaces() {
-		// The two model files are passed in reverse order: this test only works if
-		// the order of the "files" is the opposite from that provided.
-		Map<String, String> generated = generatorTestHelper.generateCode("""
-				namespace "original"
-				type A:
-					aa string (0..1)
-
-				type Top:
-					aField A (0..*)
-				""", """
+		// The extending model is passed as the primary source, so that `getTypeJavaClass`
+		// resolves `Top` to `extending.Top`.
+		JavaTestModel model = testModelService.toJavaTestModel("""
 				namespace "extending"
 
 				import original.*
@@ -110,29 +96,24 @@ class RosettaObjectInheritanceGeneratorTest {
 
 				type Top extends original.Top:
 					override aField A (0..*)
-				""");
+				""", """
+				namespace "original"
 
-		Map<String, Class<?>> classes = generatorTestHelper.compileToClasses(generated);
-		Class<?> extendingTop = classes.get("extending.Top");
+				type A:
+					aa string (0..1)
+
+				type Top:
+					aField A (0..*)
+				""").compile();
+
+		Class<?> extendingTop = model.getTypeJavaClass("Top");
 		assertThrows(NoSuchFieldException.class, () -> extendingTop.getDeclaredField("aField"));
 	}
 
 	@Disabled
 	@Test
 	void shouldGenerateJavaClassWithConditionsListAttributesAcrossNamespaces() {
-		// The two model files are passed in reverse order: this test only works if
-		// the order of the "files" is the opposite from that provided.
-		Map<String, String> generated = generatorTestHelper.generateCode("""
-				namespace "original"
-				type A:
-					b B (0..1)
-
-				type B:
-					c C (0..1)
-
-				type C:
-					cField1 string (0..*)
-				""", """
+		testModelService.toJavaTestModel("""
 				namespace "extending"
 
 				import original.*
@@ -148,10 +129,18 @@ class RosettaObjectInheritanceGeneratorTest {
 					cField3 B (0..1)
 
 					 condition cField3Exists: cField3 -> c exists
+				""", """
+				namespace "original"
 
-				""");
+				type A:
+					b B (0..1)
 
-		generatorTestHelper.compileToClasses(generated);
+				type B:
+					c C (0..1)
+
+				type C:
+					cField1 string (0..*)
+				""").compile();
 	}
 
 	@Test
@@ -163,7 +152,7 @@ class RosettaObjectInheritanceGeneratorTest {
 		// unconditionally (`Collections.singletonList(datedValue.toBuilder())`), throwing an NPE
 		// whenever an inherited condition read the attribute. The getter must instead be null-safe
 		// and return an empty list for the absent attribute.
-		Map<String, String> generated = generatorTestHelper.generateCode("""
+		JavaTestModel model = testModelService.toJavaTestModel("""
 				type DatedValue:
 					x int (0..1)
 
@@ -175,11 +164,10 @@ class RosettaObjectInheritanceGeneratorTest {
 
 				type Quantity extends Schedule:
 					override datedValue DatedValue (0..0)
-				""");
+				""").compile();
 
-		Map<String, Class<?>> classes = generatorTestHelper.compileToClasses(generated);
-
-		RosettaModelObjectBuilder builder = generatorTestHelper.createBuilderInstance(classes, "Quantity");
+		Class<?> quantityClass = model.getTypeJavaClass("Quantity");
+		RosettaModelObjectBuilder builder = (RosettaModelObjectBuilder) quantityClass.getMethod("builder").invoke(null);
 		List<?> datedValue = (List<?>) builder.getClass().getMethod("getDatedValue").invoke(builder);
 		assertEquals(List.of(), datedValue);
 	}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/object/RosettaObjectInheritanceGeneratorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/object/RosettaObjectInheritanceGeneratorTest.java
@@ -1,8 +1,10 @@
 package com.regnosys.rosetta.generator.java.object;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
 import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper;
 import com.regnosys.rosetta.tests.util.ModelHelper;
+import com.rosetta.model.lib.RosettaModelObjectBuilder;
 
 @ExtendWith(InjectionExtension.class)
 @InjectWith(RosettaTestInjectorProvider.class)
@@ -149,5 +152,35 @@ class RosettaObjectInheritanceGeneratorTest {
 				""");
 
 		generatorTestHelper.compileToClasses(generated);
+	}
+
+	@Test
+	void shouldNotThrowWhenReadingAnAttributeOverriddenToZeroCardinality() throws Exception {
+		// See https://github.com/finos/rune-dsl/issues/1321
+		// When a child type overrides a multi-cardinality parent attribute with a zero (single)
+		// cardinality, the attribute is stored as a single, always-null field. The builder getter
+		// that adapts this single field back to the parent's list type used to wrap the field
+		// unconditionally (`Collections.singletonList(datedValue.toBuilder())`), throwing an NPE
+		// whenever an inherited condition read the attribute. The getter must instead be null-safe
+		// and return an empty list for the absent attribute.
+		Map<String, String> generated = generatorTestHelper.generateCode("""
+				type DatedValue:
+					x int (0..1)
+
+				type Schedule:
+					datedValue DatedValue (0..*)
+
+					condition DatedValueExists:
+						datedValue exists
+
+				type Quantity extends Schedule:
+					override datedValue DatedValue (0..0)
+				""");
+
+		Map<String, Class<?>> classes = generatorTestHelper.compileToClasses(generated);
+
+		RosettaModelObjectBuilder builder = generatorTestHelper.createBuilderInstance(classes, "Quantity");
+		List<?> datedValue = (List<?>) builder.getClass().getMethod("getDatedValue").invoke(builder);
+		assertEquals(List.of(), datedValue);
 	}
 }

--- a/rune-integration-tests/src/test/resources/generation-regression-tests/pojo-inheritance/expected/test/pojo/Foo2.java
+++ b/rune-integration-tests/src/test/resources/generation-regression-tests/pojo-inheritance/expected/test/pojo/Foo2.java
@@ -371,7 +371,7 @@ public interface Foo2 extends Foo1 {
 		@RosettaIgnore
 		@RuneIgnore
 		public List<? extends Parent.ParentBuilder> getParentList() {
-			return parentList == null ? Collections.<Parent.ParentBuilder>emptyList() : Collections.singletonList(parentList.getValue().toBuilder());
+			return (parentList == null || parentList.getValue() == null ? Collections.<Parent>emptyList() : Collections.singletonList(parentList.getValue())).stream().map(_parent -> _parent.toBuilder()).collect(Collectors.toList());
 		}
 		
 		@Override

--- a/rune-integration-tests/src/test/resources/generation-regression-tests/pojo-inheritance/expected/test/pojo/Foo3.java
+++ b/rune-integration-tests/src/test/resources/generation-regression-tests/pojo-inheritance/expected/test/pojo/Foo3.java
@@ -419,7 +419,7 @@ public interface Foo3 extends Foo2 {
 		@RosettaIgnore
 		@RuneIgnore
 		public List<? extends Parent.ParentBuilder> getParentList() {
-			return parentList == null ? Collections.<Parent.ParentBuilder>emptyList() : Collections.singletonList(parentList.getValue().toBuilder());
+			return (parentList == null || parentList.getValue() == null ? Collections.<Parent>emptyList() : Collections.singletonList(parentList.getValue())).stream().map(_parent -> _parent.toBuilder()).collect(Collectors.toList());
 		}
 		
 		@Override

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/object/ModelObjectBuilderGenerator.xtend
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/object/ModelObjectBuilderGenerator.xtend
@@ -26,7 +26,6 @@ import jakarta.inject.Inject
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import com.rosetta.model.lib.annotations.RuneScopedAttributeReference
 import com.rosetta.model.lib.annotations.RuneScopedAttributeKey
-import com.regnosys.rosetta.generator.java.statement.builder.JavaLiteral
 import com.rosetta.model.lib.annotations.RosettaIgnore
 import com.regnosys.rosetta.generator.java.scoping.JavaClassScope
 import static com.regnosys.rosetta.generator.java.types.JavaPojoPropertyOperationType.*
@@ -174,28 +173,19 @@ class ModelObjectBuilderGenerator {
 		@«RuneIgnore»
 		public «parent.toBuilderTypeExt» «getterName»() «
 			(if (parent.type.isList) {
-				if (originalProp.type.isList) {
-					originalField
-						.addCoercions(parent.type, bodyScope)
-						.collapseToSingleExpression(bodyScope)
-						.mapExpression[
-							val lambdaParam = new JavaVariable(bodyScope.lambdaScope.createUniqueIdentifier(parent.type.itemType.simpleName.toFirstLower), parent.type.itemType)
-							JavaExpression.from(
-								'''«it».stream().map(«lambdaParam» -> «lambdaParam.toBuilder.toLambdaBody»).collect(«Collectors».toList())''',
-								parent.toBuilderTypeExt
-							)
-						]
-				} else {
-					originalField
-						.addCoercions(parent.type.itemType, bodyScope)
-						.mapExpression[
-							if (it == JavaLiteral.NULL) {
-								JavaExpression.from('''«Collections».<«parent.toBuilderTypeSingle»>emptyList()''', parent.toBuilderTypeExt)
-							} else {
-								toBuilder.mapExpression[JavaExpression.from('''«Collections».singletonList(«it»)''', parent.toBuilderTypeExt)]
-							}
-						]
-				}
+				// The child field may be either single- or multi-cardinality. In both cases,
+				// coercing it to the parent's list type is null-safe (a null item becomes an empty
+				// list), so we can uniformly map the resulting list to its builder type.
+				originalField
+					.addCoercions(parent.type, bodyScope)
+					.collapseToSingleExpression(bodyScope)
+					.mapExpression[
+						val lambdaParam = new JavaVariable(bodyScope.lambdaScope.createUniqueIdentifier(parent.type.itemType.simpleName.toFirstLower), parent.type.itemType)
+						JavaExpression.from(
+							'''«it».stream().map(«lambdaParam» -> «lambdaParam.toBuilder.toLambdaBody»).collect(«Collectors».toList())''',
+							parent.toBuilderTypeExt
+						)
+					]
 			} else {
 				originalField
 					.addCoercions(parent.type, bodyScope)


### PR DESCRIPTION
Fixes #1321.

## Summary

When a child type overrides a multi-cardinality parent attribute with a single (e.g. zero) cardinality, the attribute is stored on the child as a single, always-null field. The generated **builder** getter that adapts this single field back to the parent's `List` type wrapped the field unconditionally:

```java
public List<? extends DatedValue.DatedValueBuilder> getDatedValue() {
    return Collections.singletonList(datedValue.toBuilder());
}
```

This threw a `NullPointerException` whenever an inherited condition (or any caller) read the attribute, because `datedValue` is always `null`.

The single-cardinality branch in `ModelObjectBuilderGenerator` used a *compile-time* null check (`it == JavaLiteral.NULL`) rather than a *runtime* one. Coercing the child field to the parent's list type via `addCoercions` is already runtime null-safe (a null item becomes an empty list), so the single- and multi-cardinality branches are now unified to use it. The absent attribute now correctly yields an empty list, so the inherited `exists` condition safely evaluates to "does not exist".

The generated getter now reads:

```java
public List<? extends DatedValue.DatedValueBuilder> getDatedValue() {
    return (datedValue == null ? Collections.<DatedValue>emptyList() : Collections.singletonList(datedValue))
        .stream().map(_datedValue -> _datedValue.toBuilder()).collect(Collectors.toList());
}
```

As a side effect this also fixes a latent NPE for meta-typed overrides where the wrapper was non-null but its value was null (see the updated `Foo2`/`Foo3` regression expectations — the generated code now additionally guards `parentList.getValue() == null`).

The POJO (non-builder) getter was already null-safe and is unchanged.

## Testing

- Added `RosettaObjectInheritanceGeneratorTest.shouldNotThrowWhenReadingAnAttributeOverriddenToZeroCardinality`, which reproduces the reported hierarchy and asserts the builder getter returns an empty list instead of throwing.
- Updated the `pojo-inheritance` generation-regression expectations for the equivalent, more-null-safe generated code.
- Full `rune-integration-tests` suite passes (1488 tests, 0 failures).

## Type of change

- Bug fix (non-breaking change which fixes an issue)