### PR TITLE
Default serialiser config

### DIFF
--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneModelConfiguration.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/RuneModelConfiguration.java
@@ -7,21 +7,29 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.regnosys.rosetta.experimental.ExperimentalFeature;
+import com.rosetta.model.lib.transform.SerializationFormat;
 
 import org.apache.commons.lang3.Validate;
 
 public class RuneModelConfiguration {
 	private final String name;
 	private final List<ExperimentalFeature> enableExperimentalFeatures;
+	private final SerializationFormat defaultSerialisationFormat;
+
+	public RuneModelConfiguration(String name, List<ExperimentalFeature> enableExperimentalFeatures) {
+		this(name, enableExperimentalFeatures, null);
+	}
 
 	@JsonCreator
 	public RuneModelConfiguration(
 			@JsonProperty("name") String name,
-			@JsonProperty("enableExperimentalFeatures") List<ExperimentalFeature> enableExperimentalFeatures) {
+			@JsonProperty("enableExperimentalFeatures") List<ExperimentalFeature> enableExperimentalFeatures,
+			@JsonProperty("defaultSerialisationFormat") SerializationFormat defaultSerialisationFormat) {
 		Objects.requireNonNull(name);
 		this.name = name;
 		this.enableExperimentalFeatures = enableExperimentalFeatures == null ? Collections.emptyList() : enableExperimentalFeatures;
 		Validate.noNullElements(this.enableExperimentalFeatures);
+		this.defaultSerialisationFormat = defaultSerialisationFormat;
 	}
 
 	public String getName() {
@@ -30,5 +38,9 @@ public class RuneModelConfiguration {
 
 	public List<ExperimentalFeature> getEnableExperimentalFeatures() {
 		return enableExperimentalFeatures;
+	}
+
+	public SerializationFormat getDefaultSerialisationFormat() {
+		return defaultSerialisationFormat;
 	}
 }

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/transform/SerializationFormat.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/transform/SerializationFormat.java
@@ -10,9 +10,9 @@ package com.rosetta.model.lib.transform;
  * generated annotations and the runtime.
  */
 public enum SerializationFormat {
-    /** JSON, following a standard JSON representation of the model. */
+    /** JSON, following a legacy JSON representation of the model. */
     JSON,
-    /** JSON, following the Rune-specific JSON standard. */
+    /** JSON, following the updated flattened JSON representation of the model. */
     RUNE_JSON,
     /** XML, typically configured by an associated XML configuration file that maps the schema onto the Rune type. */
     XML,

--- a/rune-runtime/src/test/java/com/regnosys/rosetta/config/RuneConfigurationServiceTest.java
+++ b/rune-runtime/src/test/java/com/regnosys/rosetta/config/RuneConfigurationServiceTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.Arrays;
 
+import com.rosetta.model.lib.transform.SerializationFormat;
+
 import org.junit.jupiter.api.Test;
 
 class RuneConfigurationServiceTest {
@@ -126,5 +128,37 @@ class RuneConfigurationServiceTest {
 				.addNamespaceConfig(new RuneNamespaceConfiguration(null, "cdm.base.datetime", true, null))
 				.build();
 		assertEquals(2, updated.getNamespaceConfig().size());
+	}
+
+	@Test
+	void defaultSerialisationFormatIsReadWhenPresent() throws IOException {
+		String yaml = "model:\n  name: DEMO\n  defaultSerialisationFormat: RUNE_JSON\n";
+		RuneConfiguration config = service.readString(yaml);
+		assertEquals(SerializationFormat.RUNE_JSON, config.getModel().getDefaultSerialisationFormat());
+	}
+
+	@Test
+	void defaultSerialisationFormatIsNullWhenAbsent() throws IOException {
+		RuneConfiguration config = service.readString(CONFIG);
+		assertNull(config.getModel().getDefaultSerialisationFormat());
+	}
+
+	@Test
+	void defaultSerialisationFormatRoundtrips() throws IOException {
+		String yaml = "model:\n  name: DEMO\n  defaultSerialisationFormat: RUNE_JSON\n";
+		RuneConfiguration config = service.readString(yaml);
+
+		String out = service.writeString(config);
+		assertTrue(out.contains("defaultSerialisationFormat: RUNE_JSON"), out);
+
+		RuneConfiguration reread = service.readString(out);
+		assertEquals(SerializationFormat.RUNE_JSON, reread.getModel().getDefaultSerialisationFormat());
+	}
+
+	@Test
+	void absentDefaultSerialisationFormatIsNotWritten() throws IOException {
+		RuneConfiguration config = service.readString(CONFIG);
+		String out = service.writeString(config);
+		assertFalse(out.contains("defaultSerialisationFormat"), out);
 	}
 }


### PR DESCRIPTION
Adds a `defaultSerialisationFormat` field to `RuneModelConfiguration`, typed as the existing `com.rosetta.model.lib.transform.SerializationFormat` enum, so a model's `rune-config.yml` / `rosetta-config.yml` can declare which JSON mapper should be used on the **default** (no explicit format) serialisation path:

```yaml
model:
  name: Common Domain Model
  defaultSerialisationFormat: RUNE_JSON   # absent ⇒ legacy JSON
```

- New field defaults to `null` (legacy behaviour) when absent; `@JsonCreator` moved to the new widest constructor, with a backward-compatible overload keeping the existing `RuneModelConfiguration(name, enableExperimentalFeatures)` signature compiling.
- No new enum introduced — reuses `SerializationFormat` already in `rune-runtime`.
- This is purely a config-model change; nothing in the DSL's own serialisation/compilation behaviour changes. It is the prerequisite for a follow-up change in rosetta-products that will make the default JSON mapper configurable per-model.
