### PR TITLE
[9.x.x] Update CVE scanning workflow to be consistent across repos

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -1,6 +1,11 @@
 name: CVE Scanning
 
 on:
+  workflow_dispatch:
+  schedule:
+    # Run daily so that the scan re-runs even when nothing in the repo changed,
+    # picking up newly published CVEs from the live NVD database.
+    - cron: '0 3 * * *'
   push:
     branches:
       - 9.x.x
@@ -29,80 +34,71 @@ jobs:
         with:
           run-tests: false
 
-      # Steps to update the database of CVE vulnerabilities:
-      # 1. restore from cache
-      # 2. check for updates
-      # 3. save to cache
-      - name: Restore Dependency-Check DB
-        uses: actions/cache/restore@v5
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      # Persists the downloaded NVD dataset across runs, keyed by date, so that
+      # subsequent (especially daily scheduled) runs resume from where the
+      # previous run left off instead of re-downloading the whole database.
+      - name: Cache NVD data
+        uses: actions/cache@v5
         with:
           path: .dependency-check-data
-          key: ${{ runner.os }}-dependency-check-${{ github.run_id }}
+          key: nvd-data-${{ steps.date.outputs.date }}
           restore-keys: |
-            ${{ runner.os }}-dependency-check-
+            nvd-data-
 
-      - name: Warm Dependency-Check DB
+      # A partial download doesn't advance dependency-check's internal checkpoint,
+      # so a run that times out just re-requests the same delta again next time
+      # (upstream dependency-check#7180). Splitting the update into its own step
+      # with a big time budget lets it eventually complete and cache; the scan
+      # step below then runs against whatever is cached, without being blocked
+      # by a flaky/slow update.
+      - name: Update NVD data
+        id: nvd-update
+        timeout-minutes: 300 # stay under the 360-minute GitHub-hosted runner job cap
+        continue-on-error: true
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
-          mkdir -p .dependency-check-data reports
+          mvn -B org.owasp:dependency-check-maven:12.2.2:update-only \
+            -DdataDirectory="${PWD}/.dependency-check-data" \
+            -DnvdApiKeyEnvironmentVariable=NVD_API_KEY \
+            -DnvdApiDelay=6000 \
+            -DnvdMaxRetryCount=30 \
+            -DnvdApiResultsPerPage=1000
 
-          run_update() {
-            docker run --rm \
-              -u "$(id -u):$(id -g)" \
-              -v "$PWD/.dependency-check-data:/usr/share/dependency-check/data" \
-              -v "$PWD/reports:/report" \
-              owasp/dependency-check:12.2.1 \
-              --updateonly \
-              --nvdApiKey "$NVD_API_KEY" \
-              --log /report/dependency-check-update.log
-          }
-
-          run_update || {
-            echo "Initial DB update failed; showing data dir contents"
-            ls -la .dependency-check-data || true
-
-            echo "Removing partial DB/lock state and retrying once"
-            rm -rf .dependency-check-data/*
-            mkdir -p .dependency-check-data
-
-            run_update
-          }
-
-      - name: Save Dependency-Check DB
-        if: always() && success()
-        uses: actions/cache/save@v5
-        with:
-          path: .dependency-check-data
-          key: ${{ runner.os }}-dependency-check-${{ github.run_id }}
-
-      # Run the actual vulnerability scan using the cached vulnerability database
+      # Run the actual vulnerability scan using the official Maven plugin against
+      # whatever NVD data is already cached (autoUpdate=false), so this step is
+      # fast and isn't blocked by a flaky/slow NVD sync.
       - name: CVE scanning
-        # remove --centralUrl when https://search.maven.org/solrsearch/select is back online
+        id: cve-scanning
         run: |
-          mkdir -p reports
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -e JAVA_HOME=/opt/jdk \
-            -v "$PWD:/src" \
-            -v "$PWD/.dependency-check-data:/usr/share/dependency-check/data" \
-            -w /src \
-            owasp/dependency-check:12.2.1 \
-            --project "${{ github.repository }}" \
-            --scan /src \
-            --format HTML \
-            --out /src/reports \
-            --log /src/reports/dependency-check.log \
-            --noupdate \
-            --suppression /src/CVE-suppressions.xml \
-            --failOnCVSS 7 \
-            --exclude "website/**" \
-            --exclude ".github/actions/**" \
-            --disableYarnAudit \
-            --centralUrl https://central.sonatype.com/solrsearch/select
+          mvn -B org.owasp:dependency-check-maven:12.2.2:aggregate \
+            -Dname="Rune DSL" \
+            -DdataDirectory="${PWD}/.dependency-check-data" \
+            -DautoUpdate=false \
+            -DsuppressionFiles=CVE-suppressions.xml \
+            -Dformats=HTML \
+            -DoutputDirectory=reports \
+            -DfailBuildOnCVSS=7 \
+            -DossIndexAnalyzerEnabled=false \
+            -DnodeAuditAnalyzerEnabled=false
 
       - name: Upload results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: CVE Scan Report
           path: reports
+
+      - name: Note if the NVD update did not complete
+        if: steps.nvd-update.outcome == 'failure'
+        run: |
+          echo "::warning::The 'Update NVD data' step did not complete (see its log for details)."
+          if [ "${{ steps.cve-scanning.outcome }}" = "failure" ]; then
+            echo "::warning::The scan step also failed - if that failure is a NoDataException there is no cached NVD data yet (e.g. first ever run); otherwise it is likely a real CVSS>=7 finding, see the report artifact."
+          else
+            echo "::warning::The scan step still succeeded, using the last previously cached NVD data - it may be a few days stale until an update fully completes."
+          fi


### PR DESCRIPTION
* Fix the CVE scanning workflow

* Fix the CVE scanning workflow

* Do not scan node or ossIndex

Please include a summary of the change and the issue/story number.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
