### PR TITLE
Fix NPEs during intermediate typing states in AttributeValidator and ExpectedTypeProvider

### DIFF
--- a/rune-lang/src/main/java/com/regnosys/rosetta/types/ExpectedTypeProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/types/ExpectedTypeProvider.java
@@ -547,6 +547,9 @@ public interface ExpectedTypeProvider {
                             .collect(Collectors.toSet());
 
                     RMetaAnnotatedType expectedType = getExpectedTypeFromContainer(expr);
+                    if (expectedType == null || expectedType.equals(builtins.NOTHING_WITH_ANY_META)) {
+                        return expectedType;
+                    }
                     List<RMetaAttribute> metaAttributes = expectedType.getMetaAttributes()
                             .stream()
                             .filter(a -> !withMetaKeys.contains(a.getName()))

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/AttributeValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/AttributeValidator.java
@@ -55,6 +55,7 @@ public class AttributeValidator extends AbstractDeclarativeRosettaValidator {
 		if (!capitalisationSuppressed
 				&& !(attribute instanceof ChoiceOption)
 				&& !(attribute.eContainer() instanceof Annotation)
+				&& attribute.getName() != null
 				&& Character.isUpperCase(attribute.getName().charAt(0))) {
 			warning("Attribute name should start with a lower case", attribute, ROSETTA_NAMED__NAME, INVALID_CASE);
 		}


### PR DESCRIPTION
## Summary

Two robustness fixes for exceptions reported from the BSP that occur while a user is still typing in the model (i.e. the parsed AST is temporarily incomplete):

- `NullPointerException` in `AttributeValidator.checkAttributeNameStartsWithLowerCase` — `Attribute.getName()` can be `null` before the identifier is typed, and the check called `.charAt(0)` on it unguarded. Fixed by adding a null check, following the existing convention used in `ConditionValidator.checkConditionName`.
- Spurious error log in `ExpectedTypeProvider.Impl.ExpectedTypeSwitch.caseWithMetaOperation` — it resolves the expected type of a `with-meta` expression and unconditionally calls `getMetaAttributes()` on it. When the expected type can't yet be resolved (intermediate typing state), this returns `RBuiltinTypeService.NOTHING_WITH_ANY_META`, whose `getMetaAttributes()` deliberately logs an error when invoked (per its own class comment: "one should make sure that they are not calling it on NOTHING_WITH_ANY_META, otherwise an error will be logged"). Fixed by short-circuiting when the expected type is `null` or `NOTHING_WITH_ANY_META`.

Stacktraces observed:

```
java.lang.NullPointerException: Cannot invoke "String.charAt(int)" because the return value of "com.regnosys.rosetta.rosetta.simple.Attribute.getName()" is null
	at com.regnosys.rosetta.validation.AttributeValidator.checkAttributeNameStartsWithLowerCase(AttributeValidator.java:58)
```

```
ERROR c.r.r.t.b.RBuiltinTypeService - getMetaAttributes called on type NOTHING_WITH_ANY_META
	at com.regnosys.rosetta.types.builtin.RBuiltinTypeService$2.getMetaAttributes(RBuiltinTypeService.java:89)
	at com.regnosys.rosetta.types.ExpectedTypeProvider$Impl$ExpectedTypeSwitch.caseWithMetaOperation(ExpectedTypeProvider.java:550)
```

Prepared by SimonAgent agent badger. Slack thread: (internal)

## Test plan

- [ ] CI build/tests pass
- [ ] Manual review confirms both guards mirror existing null-handling conventions in the same files (`ConditionValidator`, other `getExpectedTypeFromContainer` null-returning branches)