### PR TITLE
[9.x.x] - fix: Windows compatibility — formatter line endings, URL handling, LF checkout (#1324)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Sources and expectation files are stored with LF; generator tests compare
+# generated code against fixtures, so check everything out with LF on every
+# platform (overrides core.autocrlf on Windows). This also keeps Xtend
+# template sources LF so locally built generators behave like CI builds.
+* text=auto eol=lf

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/MultiConfigUnionTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/MultiConfigUnionTest.java
@@ -88,15 +88,16 @@ public class MultiConfigUnionTest {
 		// A dependency-style config that is only reachable through a dedicated classloader, not the TCCL.
 		Files.writeString(depClasspathRoot.resolve(RuneConfigurationFileProvider.FILE_NAME),
 				"model:\n  name: Dep\nnamespaceConfig:\n- id: depOnly\n  namespace: dep.only\n  schemaConfig:\n    schema: depOnly\n    configPath: dep.json\n");
-		URLClassLoader depClassLoader = new URLClassLoader(new URL[] { depClasspathRoot.toUri().toURL() }, null);
+		// Closed before the test ends so the @TempDir can be deleted on Windows
+		try (URLClassLoader depClassLoader = new URLClassLoader(new URL[] { depClasspathRoot.toUri().toURL() }, null)) {
+			String primaryPath = Paths.get(getClass().getResource("/rune-config-test.yml").toURI()).toString();
+			RuneConfigurationFileProvider provider = RuneConfigurationFileProvider.createFromFile(primaryPath);
+			provider.setClassLoader(depClassLoader);
 
-		String primaryPath = Paths.get(getClass().getResource("/rune-config-test.yml").toURI()).toString();
-		RuneConfigurationFileProvider provider = RuneConfigurationFileProvider.createFromFile(primaryPath);
-		provider.setClassLoader(depClassLoader);
-
-		Collection<URL> resources = provider.getResources();
-		assertTrue(resources.contains(depClasspathRoot.resolve(RuneConfigurationFileProvider.FILE_NAME).toUri().toURL()),
-				"getResources() should discover dependency configs via the injected classloader");
+			Collection<URL> resources = provider.getResources();
+			assertTrue(resources.contains(depClasspathRoot.resolve(RuneConfigurationFileProvider.FILE_NAME).toUri().toURL()),
+					"getResources() should discover dependency configs via the injected classloader");
+		}
 	}
 
 	private static class UnionConfigFileProvider extends RuneConfigurationFileProvider {

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/ResourceFormatterServiceTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/ResourceFormatterServiceTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -80,6 +82,25 @@ public class ResourceFormatterServiceTest {
 	void formatNestedConstructor() throws IOException, URISyntaxException {
 		testFormatting(List.of("formatting-test/input/nestedConstructor.rosetta"),
 				List.of("formatting-test/expected/nestedConstructor.rosetta"));
+	}
+
+	@Test
+	void formatDocumentKeepsItsOwnLineSeparator() throws IOException {
+		// A document written with CRLF line endings (e.g. by an editor on Windows)
+		// must be formatted with CRLF throughout, independent of the platform.
+		String content = "namespace test\r\nversion \"1.2.3\"\r\n\r\ntype Foo:\r\n  attr int (1..1)\r\n";
+		ResourceSet resourceSet = resourceSetProvider.get();
+		Resource resource = resourceSet.createResource(URI.createURI("dummy:/crlf.rosetta"));
+		resource.load(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), null);
+
+		List<String> formattedText = new ArrayList<>();
+		formatterService.formatCollection(List.of(resource), (r, formattedContent) -> formattedText.add(formattedContent));
+
+		Assertions.assertEquals(1, formattedText.size());
+		String formatted = formattedText.get(0);
+		Assertions.assertTrue(formatted.contains("\r\n"), "formatted document should keep CRLF line endings");
+		Assertions.assertFalse(formatted.replace("\r\n", "").contains("\n"),
+				"formatted document should not mix bare LF into a CRLF document");
 	}
 
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOperationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOperationTest.java
@@ -51,7 +51,7 @@ public class ListOperationTest {
         			filter [ item -> include = True ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -152,7 +152,7 @@ public class ListOperationTest {
         			filter fooItem [ fooItem -> include = True ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -291,7 +291,7 @@ public class ListOperationTest {
         			then filter [ item -> include2 = True ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -394,7 +394,7 @@ public class ListOperationTest {
         			filter [ item -> attr -> scheme = "foo-scheme" ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -499,7 +499,7 @@ public class ListOperationTest {
         			filter [ item -> scheme = "foo-scheme" ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -576,7 +576,7 @@ public class ListOperationTest {
         			filter [ item = True ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -947,7 +947,7 @@ public class ListOperationTest {
         			extract [ if item -> include = True then Foo { include: include, attr: attr + "_bar" } else item ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -1261,7 +1261,7 @@ public class ListOperationTest {
         			extract [ item -> attr ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -1380,7 +1380,7 @@ public class ListOperationTest {
         			then extract fooListItem [ fooListItem count ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -1582,7 +1582,7 @@ public class ListOperationTest {
         			then flatten
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -1730,7 +1730,7 @@ public class ListOperationTest {
         			then extract [ item -> attr ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -1915,7 +1915,7 @@ public class ListOperationTest {
         		attr
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -2056,7 +2056,7 @@ public class ListOperationTest {
         		attr
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -2221,7 +2221,7 @@ public class ListOperationTest {
 
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -2319,7 +2319,7 @@ public class ListOperationTest {
         			then extract [ item -> fooAttr ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("ns1.functions.FuncFoo"));
+        String f = code.get("ns1.functions.FuncFoo");
         assertEquals("""
         package ns1.functions;
         
@@ -2407,7 +2407,7 @@ public class ListOperationTest {
         			then extract [ item -> attr ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model0, model1);
-        String f = normalize(code.get("ns2.functions.FuncFoo"));
+        String f = code.get("ns2.functions.FuncFoo");
         assertEquals("""
         package ns2.functions;
         
@@ -2497,7 +2497,7 @@ public class ListOperationTest {
         			then extract [ item -> fooAttr ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model0, model1);
-        String f = normalize(code.get("ns2.functions.FuncFoo"));
+        String f = code.get("ns2.functions.FuncFoo");
         assertEquals("""
         package ns2.functions;
         
@@ -2600,7 +2600,7 @@ public class ListOperationTest {
         			then extract [ item -> fooAttr ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model0, model1);
-        String f = normalize(code.get("ns2.functions.FuncFoo"));
+        String f = code.get("ns2.functions.FuncFoo");
         assertEquals("""
         package ns2.functions;
         
@@ -2685,7 +2685,7 @@ public class ListOperationTest {
         		// default else
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -2834,7 +2834,7 @@ public class ListOperationTest {
         			reduce a, b [ a + b ]
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -3308,7 +3308,7 @@ public class ListOperationTest {
         	set foo -> attr: attr
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -3626,7 +3626,7 @@ public class ListOperationTest {
         		numbers sort // sort items
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -3745,7 +3745,7 @@ public class ListOperationTest {
         		foos sort [item -> attr] // sort based on item attribute
         """;
         var code = codeGeneratorTestHelper.generateCode(model);
-        String f = normalize(code.get("com.rosetta.test.model.functions.FuncFoo"));
+        String f = code.get("com.rosetta.test.model.functions.FuncFoo");
         assertEquals("""
         package com.rosetta.test.model.functions;
         
@@ -3948,12 +3948,6 @@ public class ListOperationTest {
         List<Object> res = functionGeneratorHelper.invokeFunc(func, List.class, ImmutableList.of(foo4, foo2, foo3, foo1));
         assertEquals(4, res.size());
         assertEquals(ImmutableList.of(foo1, foo3, foo2, foo4), res);
-    }
-
-    private String normalize(String generatedCode) {
-        // The legacy code generator emits platform line endings (\r\n on Windows), whereas the
-        // expected values are Java text blocks, which the JLS normalizes to \n. Normalize before comparing.
-        return generatedCode.replace("\r\n", "\n");
     }
 
     private RosettaModelObject createFoo(Map<String, Class<?>> classes, String attr) {

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/RosettaBinaryOperationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/RosettaBinaryOperationTest.java
@@ -404,9 +404,7 @@ public class RosettaBinaryOperationTest {
         	}
         }
         """;
-        // Normalize line endings so the comparison holds on Windows, where the generator
-        // emits '\r\n' but the expected value is built with '\n'.
-        assertEquals(expected, funcFoo.replace("\r\n", "\n"));
+        assertEquals(expected, funcFoo);
         generatorTestHelper.compileToClasses(code);
     }
 

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/CalculationFunctionGeneratorTest.xtend
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/CalculationFunctionGeneratorTest.xtend
@@ -16,6 +16,13 @@ class CalculationFunctionGeneratorTest {
 
 	@Inject extension FunctionGeneratorHelper
 	@Inject extension CodeGeneratorTestHelper
+
+	// Xtend rich strings emit the platform line separator at runtime, while generated
+	// code is normalised to "\n" by CodeGeneratorTestHelper. Pin the expectation side
+	// to LF so these comparisons hold on Windows too.
+	private def lf(String s) {
+		s.replace("\r\n", "\n")
+	}
 	
 	@Test
 	def void testSimpleTransDep() {
@@ -113,7 +120,7 @@ class CalculationFunctionGeneratorTest {
 					}
 				}
 			}
-			'''.toString,
+			'''.toString.lf,
 			generated
 		)
 
@@ -353,7 +360,7 @@ class CalculationFunctionGeneratorTest {
 				}
 			}
 			'''
-		assertEquals(expected, calcJava)
+		assertEquals(expected.lf, calcJava)
 		calculation.compileToClasses
 	}
 
@@ -467,7 +474,7 @@ class CalculationFunctionGeneratorTest {
 				}
 			}
 			'''
-		assertEquals(expected, calcJava)
+		assertEquals(expected.lf, calcJava)
 	}
 
 	@Test
@@ -776,8 +783,8 @@ class CalculationFunctionGeneratorTest {
 					}
 				}
 			}
-			'''.toString, generated)
-		
+			'''.toString.lf, generated)
+
 		generatedCode.compileToClasses
 	}
 	

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorTest.java
@@ -1118,7 +1118,7 @@ public class FunctionGeneratorTest {
                 """);
 
         var funcCode = code.get("com.rosetta.test.model.functions.Foo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -2212,7 +2212,7 @@ public class FunctionGeneratorTest {
                 		result string (0..1)
                 """;
         var generatedCode = generatorTestHelper.generateCode(code);
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -2264,7 +2264,7 @@ public class FunctionGeneratorTest {
                 		result string (0..*)
                 """;
         var generatedCode = generatorTestHelper.generateCode(code);
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -2318,7 +2318,7 @@ public class FunctionGeneratorTest {
                 		result number (0..*)
                 """;
         var generatedCode = generatorTestHelper.generateCode(code);
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -2373,7 +2373,7 @@ public class FunctionGeneratorTest {
                 		result int (0..*)
                 """;
         var generatedCode = generatorTestHelper.generateCode(code);
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -2427,7 +2427,7 @@ public class FunctionGeneratorTest {
                 		result date (0..*)
                 """;
         var generatedCode = generatorTestHelper.generateCode(code);
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -2837,7 +2837,7 @@ public class FunctionGeneratorTest {
         );
 
         var extractBar = code.get("com.rosetta.test.model.agreement.functions.ExtractBar");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.agreement.functions;
 
@@ -3082,7 +3082,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f3 = code.get("com.rosetta.test.model.functions.F3");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3147,7 +3147,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f1 = code.get("com.rosetta.test.model.functions.F1");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3186,7 +3186,7 @@ public class FunctionGeneratorTest {
                 f1
         );
         var f2 = code.get("com.rosetta.test.model.functions.F2");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3261,7 +3261,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f1 = code.get("com.rosetta.test.model.functions.F1");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3303,7 +3303,7 @@ public class FunctionGeneratorTest {
                 f1
         );
         var f2 = code.get("com.rosetta.test.model.functions.F2");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3348,7 +3348,7 @@ public class FunctionGeneratorTest {
                 f2
         );
         var f3 = code.get("com.rosetta.test.model.functions.F3");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3825,7 +3825,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.DistinctFunc");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -3893,7 +3893,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.DistinctFunc");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4013,7 +4013,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.DistinctFunc");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4115,7 +4115,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.DistinctFunc");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4433,7 +4433,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4503,7 +4503,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4582,7 +4582,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4653,7 +4653,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4736,7 +4736,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4825,7 +4825,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4918,7 +4918,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -4982,7 +4982,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -5064,7 +5064,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.FuncFoo");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -5612,7 +5612,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.validation.datarule.FooBar");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.validation.datarule;
 
@@ -5707,7 +5707,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.B");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -5777,7 +5777,7 @@ public class FunctionGeneratorTest {
                 """;
         var code = generatorTestHelper.generateCode(model);
         var f = code.get("com.rosetta.test.model.functions.IsDateGreaterThan");
-        assertJavaEquals(
+        assertEquals(
                 """
 				package com.rosetta.test.model.functions;
 
@@ -5843,9 +5843,4 @@ public class FunctionGeneratorTest {
         return new java.util.ArrayList<>(Arrays.asList(elements));
     }
 
-    private static void assertJavaEquals(String expected, String actual) {
-        // The legacy generator emits platform line separators (\r\n on Windows); normalize the
-        // generated side to \n so it matches the expected Java text block, which the JLS keeps as \n.
-        assertEquals(expected, actual == null ? null : actual.replace("\r\n", "\n"));
-    }
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/LabelProviderGeneratorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/LabelProviderGeneratorTest.java
@@ -87,7 +87,9 @@ public class LabelProviderGeneratorTest {
 	private void assertSingleGeneratedFile(String expectationFileName, String expectedGeneratedPath) throws IOException {
 		GeneratedFile file = getSingleGeneratedFile();
 		Assertions.assertEquals(expectedGeneratedPath, file.getPath().replace("/test-project/src-gen/main/java", ""));
-		String actualSource = file.getContents().toString();
+		// This file comes straight from the fsa, so normalise the platform line
+		// separator emitted by the Xtend templates
+		String actualSource = file.getContents().toString().replace("\r\n", "\n");
 		String expectedSource = Resources.toString(getClass().getResource("/label-annotations/" + expectationFileName), StandardCharsets.UTF_8);
 		Assertions.assertEquals(expectedSource, actualSource);
 	}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorTest.java
@@ -163,7 +163,7 @@ class ModelMetaGeneratorTest {
 
 				}
 				""",
-				code.get("com.rosetta.test.model.validation.FooValidator").replace("\r\n", "\n"));
+				code.get("com.rosetta.test.model.validation.FooValidator"));
 		assertEquals("""
 				package com.rosetta.test.model.validation;
 
@@ -210,7 +210,7 @@ class ModelMetaGeneratorTest {
 
 				}
 				""",
-				code.get("com.rosetta.test.model.validation.FooTypeFormatValidator").replace("\r\n", "\n"));
+				code.get("com.rosetta.test.model.validation.FooTypeFormatValidator"));
 
 		Map<String, Class<?>> classes = generatorTestHelper.compileToClasses(code);
 

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/regressions/AbstractJavaGeneratorRegressionTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/regressions/AbstractJavaGeneratorRegressionTest.java
@@ -107,7 +107,9 @@ public abstract class AbstractJavaGeneratorRegressionTest {
 			} catch (IOException e) {
 				throw new UncheckedIOException(e);
 			}
-			expectedCode.put(relativePath, normalizeLineEndings(fileContents));
+			// The .gitattributes forces LF checkout for the expectation files, so no
+			// normalisation is needed on this side
+			expectedCode.put(relativePath, fileContents);
 		});
 	}
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/XtextResourceFormatter.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/XtextResourceFormatter.java
@@ -3,10 +3,13 @@ package com.regnosys.rosetta.formatting2;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.formatting2.FormatterRequest;
 import org.eclipse.xtext.formatting2.IFormatter2;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess;
@@ -15,6 +18,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 import org.eclipse.xtext.formatting2.regionaccess.TextRegionAccessBuilder;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.preferences.ITypedPreferenceValues;
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.serializer.impl.Serializer;
 import org.eclipse.xtext.util.ITextRegion;
@@ -70,11 +74,11 @@ public class XtextResourceFormatter implements ResourceFormatterService {
 		LOGGER.debug("Formatting file at location " + resource.getURI());
 
 		// setup request and formatter
+		ITextRegionAccess regionAccess = getRegionAccess(resource);
 		FormatterRequest req = formatterRequestProvider.get();
-		req.setPreferences(preferences);
+		req.setPreferences(withDocumentLineSeparator(preferences, regionAccess));
 		IFormatter2 formatter = iFormatter2Provider.get();
 
-		ITextRegionAccess regionAccess = getRegionAccess(resource);
 		req.setTextRegionAccess(regionAccess);
 
 		// list contains all the replacements which should be applied to resource
@@ -102,6 +106,26 @@ public class XtextResourceFormatter implements ResourceFormatterService {
 		String formattedString = regionRewriter.renderToString(regionAccess.regionForDocument(), replacements);
 
 		return formattedString;
+	}
+
+	/**
+	 * Unless the caller deliberately configured a line separator, format using the
+	 * separator the document already uses: Xtext's built-in fallback is the platform
+	 * separator, which would mix line endings when formatting a document that was
+	 * written on another operating system. Documents without line breaks default
+	 * to "\n".
+	 */
+	private ITypedPreferenceValues withDocumentLineSeparator(ITypedPreferenceValues preferences,
+			ITextRegionAccess regionAccess) {
+		String configured = preferences == null ? null
+				: preferences.getPreference(FormatterPreferenceKeys.lineSeparator);
+		if (configured != null && !configured.equals(FormatterPreferenceKeys.lineSeparator.getDefaultValue())) {
+			return preferences;
+		}
+		String documentSeparator = regionAccess.regionForDocument().getText().contains("\r\n") ? "\r\n" : "\n";
+		Map<String, String> overrides = new HashMap<>();
+		overrides.put(FormatterPreferenceKeys.lineSeparator.getId(), documentSeparator);
+		return new MapBasedPreferenceValues(preferences, overrides);
 	}
 
 	public FormattedImportsReplacement formattedImportsReplacement(XtextResource resource, ITextRegionAccess regionAccess) {

--- a/rune-lang/src/main/java/com/regnosys/rosetta/utils/ImportManagementService.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/utils/ImportManagementService.java
@@ -17,6 +17,8 @@ import jakarta.inject.Inject;
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.naming.QualifiedName;
 
 public class ImportManagementService {
@@ -107,6 +109,7 @@ public class ImportManagementService {
 	//TODO: adding a new line between package blocks is a whitespace operation move this to XtextResourceFormatter
 	public String toString(List<Import> imports) {
 		StringBuilder sortedImportsText = new StringBuilder();
+		String lineSeparator = detectLineSeparator(imports);
 		
 		Import previousImport = null;
 		for (Import imp : imports) {
@@ -115,19 +118,35 @@ public class ImportManagementService {
 				String previousFirstSegment = previousImport.getImportedNamespace().split("\\.")[0];
 				String currentFirstSegment = imp.getImportedNamespace().split("\\.")[0];
 				if (!previousFirstSegment.equals(currentFirstSegment)) {
-					sortedImportsText.append(System.lineSeparator());
+					sortedImportsText.append(lineSeparator);
 				}
 			}
 			sortedImportsText.append("import ").append(imp.getImportedNamespace());
 			if (imp.getNamespaceAlias() != null) {
 				sortedImportsText.append(" as ").append(imp.getNamespaceAlias());
 			}
-			sortedImportsText.append(System.lineSeparator());
+			sortedImportsText.append(lineSeparator);
 			
 			previousImport = imp;
 		}
 
 		return sortedImportsText.toString().strip();
+	}
+
+	/**
+	 * The import block is inserted into an existing document, so it uses the line
+	 * separator that document already uses (rather than the platform separator,
+	 * which would mix line endings when the document was written on another OS).
+	 * Defaults to "\n" when the document is empty or has no line breaks yet.
+	 */
+	private String detectLineSeparator(List<Import> imports) {
+		if (!imports.isEmpty()) {
+			INode node = NodeModelUtils.getNode(imports.get(0));
+			if (node != null && node.getRootNode().getText().contains("\r\n")) {
+				return "\r\n";
+			}
+		}
+		return "\n";
 	}
 
 	public boolean isSorted(List<Import> imports) {

--- a/rune-testing/src/main/java/com/regnosys/rosetta/tests/compiler/InMemoryJavacCompiler.java
+++ b/rune-testing/src/main/java/com/regnosys/rosetta/tests/compiler/InMemoryJavacCompiler.java
@@ -27,6 +27,7 @@ import java.io.StringReader;
 import java.io.Writer;
 import java.net.JarURLConnection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
@@ -271,12 +272,28 @@ public class InMemoryJavacCompiler {
 		}
 
 		private Collection<JavaFileObject> listUnder(String packageName, URL packageFolderURL) {
-			File directory = new File(packageFolderURL.getFile());
+			File directory = toFile(packageFolderURL);
 			if (directory.isDirectory()) { // browse local .class files - useful for local execution
 				return processDir(packageName, directory);
 			} else { // browse a jar file
 				return processJar(packageFolderURL);
 			} // maybe there can be something else for more involved class loaders
+		}
+
+		/**
+		 * URL.getFile() keeps URL escaping (a space becomes %20), which produces a
+		 * File that does not exist on disk. Convert via the URI instead; non-file
+		 * URLs (e.g. jar:) yield a non-directory placeholder, as before.
+		 */
+		private File toFile(URL url) {
+			if (!"file".equals(url.getProtocol())) {
+				return new File(url.getFile());
+			}
+			try {
+				return new File(url.toURI());
+			} catch (URISyntaxException e) {
+				return new File(url.getFile());
+			}
 		}
 
 		private List<JavaFileObject> processJar(URL packageFolderURL) {

--- a/rune-testing/src/main/java/com/regnosys/rosetta/tests/util/CodeGeneratorTestHelper.java
+++ b/rune-testing/src/main/java/com/regnosys/rosetta/tests/util/CodeGeneratorTestHelper.java
@@ -57,7 +57,10 @@ public class CodeGeneratorTestHelper {
 		Map<String, String> generatedCode = new LinkedHashMap<>();
 		fsa.getGeneratedFiles().forEach(it -> {
 			if (it.getJavaClassName() != null) {
-				generatedCode.put(it.getJavaClassName(), it.getContents().toString());
+				// Xtend templates emit the platform line separator at runtime; normalise
+				// to "\n" so tests can compare against text blocks and LF fixtures on
+				// every platform without ad-hoc normalisation at each call site
+				generatedCode.put(it.getJavaClassName(), it.getContents().toString().replace("\r\n", "\n"));
 			}
 		});
 


### PR DESCRIPTION
Backport of #1324 (`efe6251c7` on `main`) to the `9.x.x` line.

## What it contains

- **`XtextResourceFormatter`** — unless a caller deliberately configured one, format using the line separator the document already uses, instead of Xtext's platform-separator fallback. Regression test for a CRLF document added.
- **`ImportManagementService`** — build the sorted import block with the line separator detected from the document being edited, so sorting imports in a CRLF document no longer produces mixed line endings.
- **`InMemoryJavacCompiler`** — convert classpath URLs via `toURI()` instead of `URL.getFile()`, which keeps URL escaping and made compiled-class lookup fail on Windows paths containing spaces.
- **`CodeGeneratorTestHelper.generateCode`** — normalise generated code to `\n` once at the source, removing the scattered ad-hoc `replace("\r\n", "\n")` calls across the generator tests.
- **`MultiConfigUnionTest`** — close the `URLClassLoader` so `@TempDir` cleanup is not blocked by the open handle on Windows.
- **`.gitattributes`** — pin LF checkout on every platform.

## Backport notes

Cherry-picked with `-x`. One conflict, resolved as follows:

- `FunctionOperationGeneratorTest.java` does not exist on `9.x.x` (it is a `main`-only test), so it is dropped from the backport. The only change to it upstream was removing a now-redundant `replace("\r\n", "\n")` call.

Everything else applied cleanly. No functional differences from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)