### PR TITLE
Fix code generation for a list of lists inside a conditional or switch

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOfListsTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/expression/ListOfListsTest.java
@@ -1,0 +1,107 @@
+package com.regnosys.rosetta.generator.java.expression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.regnosys.rosetta.generator.java.types.JavaTypeUtil;
+import com.regnosys.rosetta.tests.RosettaTestInjectorProvider;
+import com.regnosys.rosetta.tests.testmodel.JavaTestModel;
+import com.regnosys.rosetta.tests.testmodel.RosettaTestModelService;
+
+/**
+ * Tests for expressions that produce a list of lists, in particular when such an expression
+ * appears in a branch of a conditional or of a switch.
+ */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(RosettaTestInjectorProvider.class)
+public class ListOfListsTest {
+    @Inject
+    private RosettaTestModelService modelService;
+    @Inject
+    private JavaTypeUtil typeUtil;
+
+    private static final String FOOS = """
+            [Foo { xs: ["a", "b"] }, Foo { xs: ["c"] }]
+            """;
+
+    @SuppressWarnings("unchecked")
+    private List<String> evaluateStringList(JavaTestModel model, String expr) {
+        return (List<String>) model.evaluateExpression(typeUtil.wrap(typeUtil.LIST, typeUtil.STRING), expr);
+    }
+
+    @Test
+    void flattenConditionalContainingListOfLists() {
+        JavaTestModel model = modelService.toJavaTestModel("""
+                type Foo:
+                    xs string (0..*)
+
+                func GetStrings:
+                    inputs:
+                        foos Foo (0..*)
+                        test boolean (1..1)
+                    output:
+                        result string (0..*)
+
+                    add result:
+                        (if test then foos extract item -> xs) flatten
+                """).compile();
+
+        assertEquals(List.of("a", "b", "c"), evaluateStringList(model, "GetStrings(" + FOOS + ", True)"));
+        assertEquals(List.of(), evaluateStringList(model, "GetStrings(" + FOOS + ", False)"));
+    }
+
+    @Test
+    void thenFlattenAfterConditionalContainingListOfLists() {
+        JavaTestModel model = modelService.toJavaTestModel("""
+                type Foo:
+                    xs string (0..*)
+
+                func GetStrings:
+                    inputs:
+                        foos Foo (0..*)
+                        test boolean (1..1)
+                    output:
+                        result string (0..*)
+
+                    add result:
+                        if test
+                        then foos extract item -> xs
+                        then flatten
+                """).compile();
+
+        assertEquals(List.of("a", "b", "c"), evaluateStringList(model, "GetStrings(" + FOOS + ", True)"));
+        assertEquals(List.of(), evaluateStringList(model, "GetStrings(" + FOOS + ", False)"));
+    }
+
+    @Test
+    void flattenSwitchContainingListOfLists() {
+        JavaTestModel model = modelService.toJavaTestModel("""
+                type Foo:
+                    xs string (0..*)
+
+                func GetStrings:
+                    inputs:
+                        foos Foo (0..*)
+                        mode string (1..1)
+                    output:
+                        result string (0..*)
+
+                    add result:
+                        (mode switch
+                            "all" then foos extract item -> xs,
+                            default empty)
+                            flatten
+                """).compile();
+
+        assertEquals(List.of("a", "b", "c"), evaluateStringList(model, "GetStrings(" + FOOS + ", \"all\")"));
+        assertEquals(List.of(), evaluateStringList(model, "GetStrings(" + FOOS + ", \"none\")"));
+    }
+}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ExpressionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ExpressionValidatorTest.java
@@ -17,7 +17,7 @@ import com.regnosys.rosetta.tests.validation.RosettaValidationTestHelper;
 
 @ExtendWith(InjectionExtension.class)
 @InjectWith(RosettaTestInjectorProvider.class)
-public class ExpressionValidatorTest {
+public class ExpressionValidatorTest extends AbstractValidatorTest {
     @Inject
     private RosettaValidationTestHelper validationTestHelper;
     @Inject
@@ -416,5 +416,112 @@ public class ExpressionValidatorTest {
 
         validationTestHelper.assertError(expr, AS_OPERATION, null,
                 "Operator `as` is not supported for type `string`. Supported argument types are complex types and choice types");
+    }
+
+    @Test
+    void listOfListsInConditionalBranchShouldError() {
+        assertIssues("""
+                type Foo:
+                    xs string (0..*)
+
+                func GetStrings:
+                    inputs:
+                        foos Foo (0..*)
+                        test boolean (1..1)
+                    output:
+                        result string (0..*)
+
+                    add result:
+                        if test
+                        then foos extract item -> xs
+                """, """
+                ERROR (null) 'Assign expression contains a list of lists, use flatten to create a list' at 15:9, length 44, on Operation
+                """);
+    }
+
+    @Test
+    void listOfListsInSwitchCaseShouldError() {
+        assertIssues("""
+                type Foo:
+                    xs string (0..*)
+
+                func GetStrings:
+                    inputs:
+                        foos Foo (0..*)
+                        mode string (1..1)
+                    output:
+                        result string (0..*)
+
+                    add result:
+                        mode switch
+                            "all" then foos extract item -> xs,
+                            default empty
+                """, """
+                ERROR (null) 'Assign expression contains a list of lists, use flatten to create a list' at 15:9, length 85, on Operation
+                """);
+    }
+
+    @Test
+    void listOfListsInOnlyOneConditionalBranchShouldError() {
+        RosettaExpression expr = modelService.toTestModel("""
+                type Foo:
+                    xs string (0..*)
+                """).parseExpression("""
+                (if test then foos extract item -> xs else foos -> xs) flatten
+                """, "foos Foo (0..*)", "test boolean (1..1)");
+
+        validationTestHelper.assertError(expr, ROSETTA_CONDITIONAL_EXPRESSION, null,
+                "Branch contains a list of lists, use flatten to create a list.");
+    }
+
+    @Test
+    void listOfListsInOnlyOneSwitchCaseShouldError() {
+        RosettaExpression expr = modelService.toTestModel("""
+                type Foo:
+                    xs string (0..*)
+                """).parseExpression("""
+                (mode switch
+                    "all" then foos extract item -> xs,
+                    default foos -> xs)
+                    flatten
+                """, "foos Foo (0..*)", "mode string (1..1)");
+
+        validationTestHelper.assertError(expr, SWITCH_CASE_OR_DEFAULT, null,
+                "Branch contains a list of lists, use flatten to create a list.");
+    }
+
+    @Test
+    void listOfListsAsOperandOfDefaultOperationShouldError() {
+        RosettaExpression expr = modelService.toTestModel("""
+                type Foo:
+                    xs string (0..*)
+                """).parseExpression("""
+                (foos extract item -> xs) default empty
+                """, "foos Foo (0..*)");
+
+        validationTestHelper.assertError(expr, DEFAULT_OPERATION, null,
+                "List must be flattened before default operation.");
+    }
+
+    @Test
+    void listOfListsAsFunctionArgumentShouldError() {
+        RosettaExpression expr = modelService.toTestModel("""
+                type Foo:
+                    xs string (0..*)
+
+                func Identity:
+                    inputs:
+                        strings string (0..*)
+                    output:
+                        result string (0..*)
+
+                    add result:
+                        strings
+                """).parseExpression("""
+                Identity(foos extract item -> xs)
+                """, "foos Foo (0..*)");
+
+        validationTestHelper.assertError(expr, ROSETTA_SYMBOL_REFERENCE, null,
+                "Argument contains a list of lists, use flatten to create a list.");
     }
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ExpressionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ExpressionValidatorTest.java
@@ -491,6 +491,32 @@ public class ExpressionValidatorTest extends AbstractValidatorTest {
     }
 
     @Test
+    void listOfListsAsListLiteralElementShouldError() {
+        RosettaExpression expr = modelService.toTestModel("""
+                type Foo:
+                    xs string (0..*)
+                """).parseExpression("""
+                ["a", foos extract item -> xs]
+                """, "foos Foo (0..*)");
+
+        validationTestHelper.assertError(expr, LIST_LITERAL, null,
+                "List element contains a list of lists, use flatten to create a list.");
+    }
+
+    @Test
+    void listOfListsAsConstructorValueShouldError() {
+        RosettaExpression expr = modelService.toTestModel("""
+                type Foo:
+                    xs string (0..*)
+                """).parseExpression("""
+                Foo { xs: foos extract item -> xs }
+                """, "foos Foo (0..*)");
+
+        validationTestHelper.assertError(expr, CONSTRUCTOR_KEY_VALUE_PAIR, null,
+                "Attribute value contains a list of lists, use flatten to create a list.");
+    }
+
+    @Test
     void listOfListsAsOperandOfDefaultOperationShouldError() {
         RosettaExpression expr = modelService.toTestModel("""
                 type Foo:
@@ -500,7 +526,7 @@ public class ExpressionValidatorTest extends AbstractValidatorTest {
                 """, "foos Foo (0..*)");
 
         validationTestHelper.assertError(expr, DEFAULT_OPERATION, null,
-                "List must be flattened before default operation.");
+                "Left operand contains a list of lists, use flatten to create a list.");
     }
 
     @Test

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/ExpressionGenerator.xtend
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/ExpressionGenerator.xtend
@@ -1156,7 +1156,7 @@ class ExpressionGenerator extends RosettaExpressionSwitch<JavaStatementBuilder, 
 	}
 
 	override protected caseThenOperation(ThenOperation expr, Context context) {
-		val thenArgCode = expr.argument.javaCode(context.withExpected(expr.argument.isMulti ? MAPPER_C.wrapExtends(expr.argument) as JavaType : MAPPER_S.wrapExtends(expr.argument)))
+		val thenArgCode = expr.argument.javaCode(context.withExpected(expr.argument.wrapperTypeOfExpression))
 		val thenAsVarCode = thenArgCode.declareAsVariable(true, "thenArg", context.scope)
 		if (expr.function.parameters.size == 0) {
 			context.scope.createKeySynonym(expr.function.implicitVarInContext, thenArgCode)
@@ -1165,10 +1165,23 @@ class ExpressionGenerator extends RosettaExpressionSwitch<JavaStatementBuilder, 
 		}
 		thenAsVarCode
 			.then(
-				expr.function.body.javaCode(context.withExpected(expr.isMulti ? MAPPER_C.wrapExtends(expr) as JavaType : MAPPER_S.wrapExtends(expr))),
+				expr.function.body.javaCode(context.withExpected(expr.wrapperTypeOfExpression)),
 				[a, b| b],
 				context.scope
 			)
+	}
+	/**
+	 * The Java wrapper type that represents the value of the given expression:
+	 * a `MapperListOfLists` for a list of lists, a `MapperC` for a list, and a `MapperS` otherwise.
+	 */
+	private def JavaType wrapperTypeOfExpression(RosettaExpression expr) {
+		if (expr.isOutputListOfLists) {
+			MAPPER_LIST_OF_LISTS.wrapExtends(expr) as JavaType
+		} else if (expr.isMulti) {
+			MAPPER_C.wrapExtends(expr) as JavaType
+		} else {
+			MAPPER_S.wrapExtends(expr) as JavaType
+		}
 	}
 
 	private def JavaStatementBuilder conversionOperation(RosettaUnaryOperation expr, Context context, StringConcatenationClient conversion, Class<? extends Exception> errorClass) {

--- a/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/TypeCoercionService.xtend
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/generator/java/expression/TypeCoercionService.xtend
@@ -12,6 +12,7 @@ import com.regnosys.rosetta.generator.java.types.JavaTypeUtil
 import com.regnosys.rosetta.generator.java.types.RJavaWithMetaValue
 import com.rosetta.model.lib.expression.ComparisonResult
 import com.rosetta.model.lib.mapper.MapperC
+import com.rosetta.model.lib.mapper.MapperListOfLists
 import com.rosetta.model.lib.mapper.MapperS
 import com.rosetta.util.types.JavaPrimitiveType
 import com.rosetta.util.types.JavaReferenceType
@@ -382,6 +383,8 @@ class TypeCoercionService {
 			JavaExpression.from('''«MapperS».<«itemType»>ofNull()''', MAPPER_S.wrap(itemType))
 		} else if (expected.isMapperC) {
 			JavaExpression.from('''«MapperC».<«itemType»>ofNull()''', MAPPER_C.wrap(itemType))
+		} else if (expected.isMapperListOfLists) {
+			JavaExpression.from('''«MapperListOfLists».<«itemType»>of(«Collections».emptyList())''', MAPPER_LIST_OF_LISTS.wrap(itemType))
 		} else if (expected.isComparisonResult) {
 			JavaExpression.from('''«ComparisonResult».ofEmpty()''', COMPARISON_RESULT)
 		} else if (expected == JavaPrimitiveType.BOOLEAN) {

--- a/rune-lang/src/main/java/com/regnosys/rosetta/types/CardinalityProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/types/CardinalityProvider.java
@@ -217,7 +217,9 @@ public class CardinalityProvider extends RosettaExpressionSwitch<Boolean, Map<Ro
         return safeIsOutputListOfLists(expr, new HashMap<>());
     }
 	private boolean safeIsOutputListOfLists(RosettaExpression expr, Map<RosettaSymbol, Boolean> cycleTracker) {
-        if (expr instanceof FlattenOperation) {
+        if (expr == null) {
+            return false;
+        } else if (expr instanceof FlattenOperation) {
             return false;
         } else if (expr instanceof MapOperation) {
             MapOperation mapOperation = (MapOperation) expr;
@@ -250,6 +252,19 @@ public class CardinalityProvider extends RosettaExpressionSwitch<Boolean, Map<Ro
         } else if (expr instanceof CanHandleListOfLists) {
             CanHandleListOfLists listExpression = (CanHandleListOfLists) expr;
             return safeIsOutputListOfLists(listExpression.getArgument(), cycleTracker);
+        } else if (expr instanceof RosettaConditionalExpression) {
+            // A conditional yields a list of lists if any of its branches does.
+            RosettaConditionalExpression conditional = (RosettaConditionalExpression) expr;
+            return safeIsOutputListOfLists(conditional.getIfthen(), cycleTracker)
+                    || safeIsOutputListOfLists(conditional.getElsethen(), cycleTracker);
+        } else if (expr instanceof SwitchOperation) {
+            // A switch yields a list of lists if any of its cases does.
+            for (SwitchCaseOrDefault switchCase : ((SwitchOperation) expr).getCases()) {
+                if (safeIsOutputListOfLists(switchCase.getExpression(), cycleTracker)) {
+                    return true;
+                }
+            }
+            return false;
         }
         return false;
     }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/AbstractExpressionValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/AbstractExpressionValidator.java
@@ -144,6 +144,25 @@ public class AbstractExpressionValidator extends AbstractDeclarativeRosettaValid
 		return true;
 	}
 
+	/**
+	 * Check that the given expression is not a list of lists. Only the operations that explicitly
+	 * support a list of lists (see {@code CanHandleListOfLists}) and the branches of a conditional
+	 * or switch expression can handle one - anywhere else it must be flattened first.
+	 *
+	 * @param description how the expression is used, e.g. "Argument". It is the subject of the error message.
+	 */
+	protected boolean isNotListOfListsCheck(RosettaExpression expr, EObject sourceObject, EStructuralFeature feature, String description) {
+		return isNotListOfListsCheck(expr, sourceObject, feature, INSIGNIFICANT_INDEX, description);
+	}
+
+	protected boolean isNotListOfListsCheck(RosettaExpression expr, EObject sourceObject, EStructuralFeature feature, int featureIndex, String description) {
+		if (expr != null && cardinalityProvider.isOutputListOfLists(expr)) {
+			error(description + " contains a list of lists, use flatten to create a list.", sourceObject, feature, featureIndex);
+			return false;
+		}
+		return true;
+	}
+
 	protected boolean commonTypeCheck(RosettaExpression expr1, RosettaExpression expr2, EObject sourceObject, EStructuralFeature feature) {
 		if (expr1 == null || expr2 == null) {
 			return true;

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/ConstructorValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/ConstructorValidator.java
@@ -56,6 +56,7 @@ public class ConstructorValidator extends AbstractExpressionValidator {
 				if (!cardinalityProvider.isFeatureMulti(feature)) {
 					isSingleCheck(expr, pair, CONSTRUCTOR_KEY_VALUE_PAIR__VALUE, "Cannot assign a list to a single value");
 				}
+				isNotListOfListsCheck(expr, pair, CONSTRUCTOR_KEY_VALUE_PAIR__VALUE, "Attribute value");
 			}
 		}
 		

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/ExpressionValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/ExpressionValidator.java
@@ -4,6 +4,7 @@ import com.regnosys.rosetta.rosetta.simple.*;
 import com.regnosys.rosetta.types.*;
 import jakarta.inject.Inject;
 
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.validation.Check;
@@ -108,6 +109,68 @@ public class ExpressionValidator extends AbstractExpressionValidator {
 		subtypeCheck(builtins.BOOLEAN_WITH_NO_META, c.getExpression(), c, CONDITION__EXPRESSION, actual -> "A condition must be a boolean");
 	}
 	
+	/**
+	 * A list of lists can only be handled by the operations that explicitly support it
+	 * (see {@code CanHandleListOfLists}), and by the branches of a conditional or switch.
+	 * Anywhere else it must be flattened first - without this check the generated Java
+	 * code does not compile.
+	 */
+	@Check
+	public void checkListOfListsInBinaryOperation(RosettaBinaryOperation op) {
+		listOfListsCheck(op.getLeft(), op, ROSETTA_BINARY_OPERATION__LEFT, op.getOperator());
+		listOfListsCheck(op.getRight(), op, ROSETTA_BINARY_OPERATION__RIGHT, op.getOperator());
+	}
+
+	private void listOfListsCheck(RosettaExpression expr, EObject source, EStructuralFeature feature, String operator) {
+		if (expr != null && cardinalityProvider.isOutputListOfLists(expr)) {
+			error("List must be flattened before " + operator + " operation.", source, feature);
+		}
+	}
+
+	/**
+	 * A conditional expression is a list of lists if one of its branches is. All of its other
+	 * branches must then be a list of lists as well, or be empty.
+	 */
+	@Check
+	public void checkListOfListsInConditionalExpression(RosettaConditionalExpression expr) {
+		checkBranchesAgreeOnListOfLists(List.of(
+				new Branch(expr.getIfthen(), expr, ROSETTA_CONDITIONAL_EXPRESSION__IFTHEN),
+				new Branch(expr.getElsethen(), expr, ROSETTA_CONDITIONAL_EXPRESSION__ELSETHEN)));
+	}
+
+	/**
+	 * See {@link #checkListOfListsInConditionalExpression(RosettaConditionalExpression)}.
+	 */
+	@Check
+	public void checkListOfListsInSwitchOperation(SwitchOperation expr) {
+		checkBranchesAgreeOnListOfLists(expr.getCases().stream()
+				.map(c -> new Branch(c.getExpression(), c, SWITCH_CASE_OR_DEFAULT__EXPRESSION))
+				.toList());
+	}
+
+	private record Branch(RosettaExpression expression, EObject source, EStructuralFeature feature) {
+	}
+
+	private void checkBranchesAgreeOnListOfLists(List<Branch> branches) {
+		Map<Boolean, List<Branch>> partition = branches.stream()
+				.collect(Collectors.partitioningBy(b -> b.expression() != null && cardinalityProvider.isOutputListOfLists(b.expression())));
+		List<Branch> listOfListsBranches = partition.get(true);
+		if (listOfListsBranches.isEmpty()) {
+			return;
+		}
+		boolean allOtherBranchesAreEmpty = partition.get(false).stream().allMatch(this::isEmptyExpression);
+		if (allOtherBranchesAreEmpty) {
+			return;
+		}
+		listOfListsBranches.forEach(b ->
+			error("Branch contains a list of lists, use flatten to create a list.", b.source(), b.feature()));
+	}
+
+	private boolean isEmptyExpression(Branch branch) {
+		return branch.expression() == null
+				|| builtins.NOTHING.equals(typeProvider.getRMetaAnnotatedType(branch.expression()).getRType());
+	}
+
 	@Check
 	public void checkFunctionOperation(Operation op) {
 		RosettaExpression expr = op.getExpression();
@@ -345,6 +408,15 @@ public class ExpressionValidator extends AbstractExpressionValidator {
         if (ecoreUtil.isResolved(callable)) {
             int paramCount = callable.numberOfParameters();
             int argCount = expr.getArgs().size();
+            for (int i = 0; i < argCount; i++) {
+                if (cardinalityProvider.isOutputListOfLists(expr.getArgs().get(i))) {
+                    if (expr.isExplicitArguments()) {
+                        error("Argument contains a list of lists, use flatten to create a list.", expr, ROSETTA_CALLABLE_REFERENCE__RAW_ARGS, i);
+                    } else {
+                        error("Argument contains a list of lists, use flatten to create a list.", expr, null);
+                    }
+                }
+            }
             if (paramCount != argCount) {
                 error("Expected " + paramCount + " argument" + (paramCount == 1 ? "" : "s") + ", but got " + argCount + " instead", expr, null);
             }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/ExpressionValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/expression/ExpressionValidator.java
@@ -109,22 +109,10 @@ public class ExpressionValidator extends AbstractExpressionValidator {
 		subtypeCheck(builtins.BOOLEAN_WITH_NO_META, c.getExpression(), c, CONDITION__EXPRESSION, actual -> "A condition must be a boolean");
 	}
 	
-	/**
-	 * A list of lists can only be handled by the operations that explicitly support it
-	 * (see {@code CanHandleListOfLists}), and by the branches of a conditional or switch.
-	 * Anywhere else it must be flattened first - without this check the generated Java
-	 * code does not compile.
-	 */
 	@Check
 	public void checkListOfListsInBinaryOperation(RosettaBinaryOperation op) {
-		listOfListsCheck(op.getLeft(), op, ROSETTA_BINARY_OPERATION__LEFT, op.getOperator());
-		listOfListsCheck(op.getRight(), op, ROSETTA_BINARY_OPERATION__RIGHT, op.getOperator());
-	}
-
-	private void listOfListsCheck(RosettaExpression expr, EObject source, EStructuralFeature feature, String operator) {
-		if (expr != null && cardinalityProvider.isOutputListOfLists(expr)) {
-			error("List must be flattened before " + operator + " operation.", source, feature);
-		}
+		isNotListOfListsCheck(op.getLeft(), op, ROSETTA_BINARY_OPERATION__LEFT, "Left operand");
+		isNotListOfListsCheck(op.getRight(), op, ROSETTA_BINARY_OPERATION__RIGHT, "Right operand");
 	}
 
 	/**
@@ -349,6 +337,9 @@ public class ExpressionValidator extends AbstractExpressionValidator {
 	@Check
 	public void checkListLiteral(ListLiteral expr) {
 		commonTypeCheck(expr.getElements(), expr, LIST_LITERAL__ELEMENTS);
+		for (int i = 0; i < expr.getElements().size(); i++) {
+			isNotListOfListsCheck(expr.getElements().get(i), expr, LIST_LITERAL__ELEMENTS, i, "List element");
+		}
 	}
 	
 	@Check
@@ -409,12 +400,10 @@ public class ExpressionValidator extends AbstractExpressionValidator {
             int paramCount = callable.numberOfParameters();
             int argCount = expr.getArgs().size();
             for (int i = 0; i < argCount; i++) {
-                if (cardinalityProvider.isOutputListOfLists(expr.getArgs().get(i))) {
-                    if (expr.isExplicitArguments()) {
-                        error("Argument contains a list of lists, use flatten to create a list.", expr, ROSETTA_CALLABLE_REFERENCE__RAW_ARGS, i);
-                    } else {
-                        error("Argument contains a list of lists, use flatten to create a list.", expr, null);
-                    }
+                if (expr.isExplicitArguments()) {
+                    isNotListOfListsCheck(expr.getArgs().get(i), expr, ROSETTA_CALLABLE_REFERENCE__RAW_ARGS, i, "Argument");
+                } else {
+                    isNotListOfListsCheck(expr.getArgs().get(i), expr, null, "Argument");
                 }
             }
             if (paramCount != argCount) {


### PR DESCRIPTION
A list of lists that appears in a branch of a conditional or switch expression is not detected as such, which results in generated Java code that does not compile. Reported on a CDM extension model, where

```
add resolvedResetDates -> dates:
    if frequencyMatches
    then baseResetDates
    else
    if isWeeklyRoll
    then calculationPeriodsData extract GenerateWeeklyResetSchedule(...)
```

generated `.addDates(ifThenElseResult)` with `ifThenElseResult` typed as `java.lang.Object`:

```
error: no suitable method found for addDates(java.lang.Object)
```

## Cause

`CardinalityProvider#isOutputListOfLists` only walked through `extract`, `filter`, `then` and `flatten`, never into the branches of a conditional or switch. Since `GenerateWeeklyResetSchedule` outputs a list and `calculationPeriodsData` is a list, that `extract` produces a list of lists, but it stayed invisible to `checkFunctionOperation`, so the model validated without issues.

Code generation then emitted a `MapperListOfLists` for that branch and a `List` for the other one. `TypeCoercionService` has no conversion out of `MapperListOfLists` and silently leaves the expression unchanged when it cannot convert, so `JavaIfThenElseBuilder` joined the two branch types into `java.lang.Object`.

Minimal reproduction:

```
type Foo:
    xs string (0..*)

func FuncFoo:
    inputs:
        foos Foo (0..*)
        test boolean (1..1)
    output:
        result string (0..*)

    add result:
        if test
        then foos extract item -> xs
```

## Changes

- `CardinalityProvider`: a conditional or switch is a list of lists if any of its branches is. Models like the one above are now reported with the existing `Assign expression contains a list of lists, use flatten to create a list` error.
- `ExpressionValidator`: all branches of a conditional or switch must agree on whether they are a list of lists (empty branches excepted) - there is no representation for a mix of the two.
- `ExpressionValidator`: a list of lists is now also rejected as an operand of a binary operation (e.g. `default`) and as an argument of a function or rule call. Both cases used to generate Java code that does not compile as well, without any validation error.
- `ExpressionGenerator` and `TypeCoercionService`: `then` and the empty representation of a `MapperListOfLists` are supported, so a conditional or switch that consistently produces a list of lists can be flattened afterwards, e.g. `(if test then foos extract item -> xs) flatten`.

The workaround for existing models is to flatten inside the branch: `then (calculationPeriodsData extract GenerateWeeklyResetSchedule(...) then flatten)`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Note that models which relied on the unreported cases above will now get a validation error, but they could not have compiled before.

## Tests

- `ListOfListsTest`: new, covers generation and evaluation of a list of lists inside a conditional and a switch, followed by `flatten` or `then flatten`.
- `ExpressionValidatorTest`: six new cases for the validations above.