### PR TITLE
Fix invalid Renovate config: remove redundant * from matchPackageNames

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,6 @@
       "groupName": "all non-breaking dependencies",
       "groupSlug": "all-non-breaking",
       "matchPackageNames": [
-        "*",
         "!/^org\\.eclipse\\./"
       ]
     }


### PR DESCRIPTION
## Summary

Fixes #1254 — Renovate had stopped creating PRs because `.github/renovate.json` failed its config validation.

`packageRules[1].matchPackageNames` combined `"*"` with a negation pattern (`"!/^org\\.eclipse\\./"`). Renovate's [string pattern matching rules](https://docs.renovatebot.com/string-pattern-matching/) state that `*` is a special case meaning "match everything" and is not valid to combine with any other pattern (positive or negative) — this validation is enforced at parse time, which is why the rule (present in this form since #1063) only started failing once Renovate itself began rejecting it, not because of a local repo change.

Since a negation-only array (`["!/^org\\.eclipse\\./"]`) already means "match everything except org.eclipse.*", the `"*"` entry was redundant and is removed.

Prepared by SimonAgent agent turtle. Slack thread: https://regnosys.slack.com/archives/CLWETR2A1/p1781173731523399

## Test plan

- [x] Validated `.github/renovate.json` is still valid JSON
- [ ] Renovate dependency dashboard should stop showing the "Action Required: Fix Renovate Configuration" issue after merge