### PR TITLE
Optimise sample flattening to reduce CPU and memory use

### DIFF
--- a/rune-integration-tests/src/test/java/com/rosetta/model/lib/flatten/ModelObjectFlattenerTest.java
+++ b/rune-integration-tests/src/test/java/com/rosetta/model/lib/flatten/ModelObjectFlattenerTest.java
@@ -120,6 +120,49 @@ class ModelObjectFlattenerTest {
 	}
 
 	@Test
+	void flattenTestWithMetadataNestedSeveralLevelsDeep() throws IOException {
+		JavaTestModel model = modelService.toJavaTestModel("""
+				namespace test
+
+				type Root:
+				    outer Outer (0..*)
+
+				type Outer:
+				    inner Inner (0..*)
+
+				type Inner:
+				    [metadata key]
+				    val string (0..*)
+				        [metadata scheme]
+				""").compile();
+
+		RosettaModelObject instance = model.evaluateExpression(RosettaModelObject.class, """
+				Root {
+		            outer: [
+		                Outer {
+		                    inner: [
+		                        Inner { val: ["A", "B"] },
+		                        Inner { val: ["C"] }
+		                    ]
+		                },
+		                Outer {
+		                    inner: [
+		                        Inner { val: ["D"] }
+		                    ]
+		                }
+		            ]
+		        }
+				""");
+
+		assertFlattenedValues(instance, """
+				outer(0).inner(0).val(0): A
+				outer(0).inner(0).val(1): B
+				outer(0).inner(1).val(0): C
+				outer(1).inner(0).val(0): D
+				""");
+	}
+
+	@Test
 	void flattenTestWithInheritance() throws IOException {
 		JavaTestModel model = modelService.toJavaTestModel("""
 				namespace test

--- a/rune-integration-tests/src/test/java/com/rosetta/model/lib/flatten/ModelObjectFlattenerTest.java
+++ b/rune-integration-tests/src/test/java/com/rosetta/model/lib/flatten/ModelObjectFlattenerTest.java
@@ -15,6 +15,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.stream.Collectors;
 
 @ExtendWith(InjectionExtension.class)
@@ -160,6 +161,32 @@ class ModelObjectFlattenerTest {
 				outer(0).inner(1).val(0): C
 				outer(1).inner(0).val(0): D
 				""");
+	}
+
+	@Test
+	void flattenAbandonsWorkWhenTheCallingThreadIsInterrupted() throws IOException {
+		JavaTestModel model = modelService.toJavaTestModel("""
+				namespace test
+
+				type Root:
+				    a string (0..1)
+				""").compile();
+		RosettaModelObject instance = model.evaluateExpression(RosettaModelObject.class, """
+				Root { a: "VALUE" }
+				""");
+
+		// sanity check: it flattens normally when not interrupted
+		Assertions.assertEquals(1, modelObjectFlattener.flatten(instance).size());
+
+		try {
+			Thread.currentThread().interrupt();
+			Assertions.assertThrows(CancellationException.class, () -> modelObjectFlattener.flatten(instance));
+			Assertions.assertTrue(Thread.currentThread().isInterrupted(),
+				"the interrupt flag must be left set for the caller to act on");
+		} finally {
+			// clear the flag so it cannot leak into other tests on this thread
+			Thread.interrupted();
+		}
 	}
 
 	@Test

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/flatten/ModelObjectFlattener.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/flatten/ModelObjectFlattener.java
@@ -9,7 +9,7 @@ import com.rosetta.model.lib.process.AttributeMeta;
 import com.rosetta.model.lib.process.BuilderProcessor;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.concurrent.CancellationException;
 
 /**
  * Flattens a {@link RosettaModelObject} into a list of {@link RosettaPathValue} objects.
@@ -19,10 +19,22 @@ import java.util.stream.Collectors;
 public class ModelObjectFlattener {
 
     /**
+     * How many visited nodes to cover per interrupt check. Flattening is uninterruptible CPU work,
+     * so callers that bound it with a timeout need it to observe interruption; polling in batches
+     * keeps the cost of that immeasurably small relative to the work done per node.
+     */
+    private static final int INTERRUPT_CHECK_MASK = 1023;
+
+    /**
      * Flattens the provided RosettaModelObject.
+     * <p>
+     * Large objects can take a long time to flatten, so this honours interruption of the calling
+     * thread: if the thread's interrupt flag is set, flattening abandons its work and throws
+     * {@link CancellationException}. The interrupt flag is left set for the caller to act on.
      *
      * @param modelObject The RosettaModelObject to flatten.
      * @return A list of RosettaPathValue objects representing the flattened object.
+     * @throws CancellationException if the calling thread is interrupted while flattening.
      */
     public List<RosettaPathValue> flatten(RosettaModelObject modelObject) {
         FlattenerBuilderProcessor processor = new FlattenerBuilderProcessor();
@@ -32,6 +44,18 @@ public class ModelObjectFlattener {
         List<RosettaPathValue> pathValues = processor.getRosettaPathValue();
 
         return removeAllMetaPaths(metaPaths, pathValues);
+    }
+
+    /**
+     * Aborts if the calling thread has been interrupted, checking only once every
+     * {@link #INTERRUPT_CHECK_MASK}+1 calls.
+     *
+     * @param visitCount a monotonically increasing count of nodes visited so far.
+     */
+    private static void abortIfInterrupted(int visitCount) {
+        if ((visitCount & INTERRUPT_CHECK_MASK) == 0 && Thread.currentThread().isInterrupted()) {
+            throw new CancellationException("Interrupted while flattening a model object");
+        }
     }
 
     /**
@@ -47,7 +71,9 @@ public class ModelObjectFlattener {
         // rather than O(metaPaths). This is the dominant cost when flattening large samples.
         Set<RosettaPath> metaPathSet = new HashSet<>(metaPaths);
         List<RosettaPathValue> result = new ArrayList<>(pathValues.size());
+        int visited = 0;
         for (RosettaPathValue pathValue : pathValues) {
+            abortIfInterrupted(visited++);
             result.add(new RosettaPathValue(removeAllMetaPaths(metaPathSet, pathValue.getPath()), pathValue.getValue()));
         }
         return result;
@@ -97,6 +123,7 @@ public class ModelObjectFlattener {
 
         private final List<RosettaPathValue> rosettaPathValues = new ArrayList<>();
         private final List<RosettaPath> metaPaths = new ArrayList<>();
+        private int visited;
 
         /**
          * Returns the list of identified metadata paths.
@@ -116,6 +143,7 @@ public class ModelObjectFlattener {
 
         @Override
         public <R extends RosettaModelObject> boolean processRosetta(RosettaPath path, Class<R> rosettaType, RosettaModelObjectBuilder builder, RosettaModelObjectBuilder parent, AttributeMeta... metas) {
+            abortIfInterrupted(visited++);
             if (builder != null && parent instanceof FieldWithMeta) {
                 metaPaths.add(path);
             }
@@ -133,6 +161,7 @@ public class ModelObjectFlattener {
 
         @Override
         public <T> void processBasic(RosettaPath path, Class<T> rosettaType, T instance, RosettaModelObjectBuilder parent, AttributeMeta... metas) {
+            abortIfInterrupted(visited++);
             if (instance != null) {
                 if (parent instanceof FieldWithMeta) {
                     rosettaPathValues.add(new RosettaPathValue(path.getParent(), instance));

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/flatten/ModelObjectFlattener.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/flatten/ModelObjectFlattener.java
@@ -42,31 +42,51 @@ public class ModelObjectFlattener {
      * @return A new list of RosettaPathValues with metadata paths removed.
      */
     private List<RosettaPathValue> removeAllMetaPaths(List<RosettaPath> metaPaths, List<RosettaPathValue> pathValues) {
-        return pathValues.stream()
-                .map(pathValue -> new RosettaPathValue(removeAllMetaPaths(metaPaths, pathValue.getPath()), pathValue.getValue()))
-                .collect(Collectors.toList());
+        // A meta path is always a prefix of the value paths it applies to, so testing every value
+        // path against every meta path is unnecessary: looking each ancestor up in a set is O(depth)
+        // rather than O(metaPaths). This is the dominant cost when flattening large samples.
+        Set<RosettaPath> metaPathSet = new HashSet<>(metaPaths);
+        List<RosettaPathValue> result = new ArrayList<>(pathValues.size());
+        for (RosettaPathValue pathValue : pathValues) {
+            result.add(new RosettaPathValue(removeAllMetaPaths(metaPathSet, pathValue.getPath()), pathValue.getValue()));
+        }
+        return result;
     }
 
     /**
      * Removes all metadata path segments from the provided RosettaPath.
      *
-     * @param metaPaths The list of metadata paths to use for filtering.
+     * @param metaPaths The metadata paths to use for filtering.
      * @param path      The RosettaPath to filter.
-     * @return A new RosettaPath with metadata segments removed.
+     * @return A new RosettaPath with metadata segments removed, and its first element trimmed.
      */
-    private RosettaPath removeAllMetaPaths(List<RosettaPath> metaPaths, RosettaPath path) {
-        LinkedList<RosettaPath.Element> elements = path.allElements();
-        metaPaths.stream()
-                .filter(path::startsWith)
-                .map(RosettaPath::allElements)
-                .map(LinkedList::size)
-                .map(i -> i - 1)
-                .distinct()
-                .sorted(Comparator.reverseOrder())
-                .forEach(i -> elements.remove((int) i));
+    private RosettaPath removeAllMetaPaths(Set<RosettaPath> metaPaths, RosettaPath path) {
+        int depth = path.depth();
+        RosettaPath.Element[] elements = new RosettaPath.Element[depth];
+        boolean[] isMetaSegment = new boolean[depth];
 
-        RosettaPath newPath = RosettaPath.createPathFromElements(elements);
-        return newPath.trimFirst();
+        int i = depth - 1;
+        for (RosettaPath ancestor = path; ancestor != null; ancestor = ancestor.getParent(), i--) {
+            elements[i] = ancestor.getElement();
+            // an ancestor that is itself a meta path contributes the segment naming the metadata field
+            isMetaSegment[i] = metaPaths.contains(ancestor);
+        }
+
+        RosettaPath result = null;
+        boolean firstRemainingTrimmed = false;
+        for (int j = 0; j < depth; j++) {
+            if (isMetaSegment[j]) {
+                continue;
+            }
+            if (!firstRemainingTrimmed) {
+                firstRemainingTrimmed = true;
+                continue;
+            }
+            result = result == null
+                    ? RosettaPath.createPath(elements[j])
+                    : result.newSubPath(elements[j]);
+        }
+        return result;
     }
 
     /**

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/path/RosettaPath.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/path/RosettaPath.java
@@ -43,7 +43,10 @@ public class RosettaPath implements Comparable<RosettaPath> {
 	
     private final RosettaPath parent;
     private final Element element;
-    
+    // number of elements from the root to this path (inclusive); cached so startsWith()
+    // can align two paths without repeatedly rebuilding LinkedLists via allElements()
+    private final int depth;
+
     //a Path that has 0 notional elements so when you create a subPath from it you get a path with 1 element
     public static class NullPath extends RosettaPath {
     	public NullPath() {
@@ -58,6 +61,7 @@ public class RosettaPath implements Comparable<RosettaPath> {
     private RosettaPath(RosettaPath parent, Element element) {
         this.parent = parent;
         this.element = element;
+        this.depth = (parent == null ? 0 : parent.depth) + 1;
     }
 
     public static RosettaPath createPath(RosettaPath parent, Element element) {
@@ -148,6 +152,13 @@ public class RosettaPath implements Comparable<RosettaPath> {
         return parent;
     }
 
+    /**
+     * @return the number of elements from the root to this path, inclusive.
+     */
+    public int depth() {
+        return depth;
+    }
+
     public Element getElement() {
         return element;
     }
@@ -173,20 +184,29 @@ public class RosettaPath implements Comparable<RosettaPath> {
     	return parent.containsPath(subPath);
     }
 
+    // Walks the parent chains directly instead of materialising allElements() LinkedLists,
+    // which showed up as the dominant CPU/allocation hotspot when flattening large samples
+    // (many startsWith checks against many meta paths) - see STORY-1843.
     public boolean startsWith(RosettaPath other) {
-        LinkedList<RosettaPath.Element> list = this.allElements();
-        LinkedList<RosettaPath.Element> prefix = other.allElements();
-        if (prefix == null || prefix.isEmpty()) {
+        if (other.depth == 0) {
             return true;
         }
-        if (list == null || list.size() < prefix.size()) {
+        if (this.depth < other.depth) {
             return false;
         }
 
-        for (int i = 0; i < prefix.size(); i++) {
-            if (!list.get(i).equals(prefix.get(i))) {
+        RosettaPath cursor = this;
+        for (int toSkip = this.depth - other.depth; toSkip > 0; toSkip--) {
+            cursor = cursor.parent;
+        }
+
+        RosettaPath otherCursor = other;
+        while (otherCursor != null) {
+            if (!Objects.equals(cursor.element, otherCursor.element)) {
                 return false;
             }
+            cursor = cursor.parent;
+            otherCursor = otherCursor.parent;
         }
 
         return true;

--- a/rune-runtime/src/test/java/com/rosetta/model/lib/path/RosettaPathTest.java
+++ b/rune-runtime/src/test/java/com/rosetta/model/lib/path/RosettaPathTest.java
@@ -255,6 +255,53 @@ public class RosettaPathTest {
     }
     
     @Test
+    void shouldStartWithItself() {
+    	RosettaPath p = RosettaPath.valueOf("a.b.c");
+    	assertThat(p.startsWith(p), is(true));
+    }
+
+    @Test
+    void shouldStartWithProperPrefix() {
+    	RosettaPath p = RosettaPath.valueOf("a.b.c.d");
+    	assertThat(p.startsWith(RosettaPath.valueOf("a")), is(true));
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b")), is(true));
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b.c")), is(true));
+    }
+
+    @Test
+    void shouldNotStartWithLongerPath() {
+    	assertThat(RosettaPath.valueOf("a.b").startsWith(RosettaPath.valueOf("a.b.c")), is(false));
+    }
+
+    @Test
+    void shouldNotStartWithDivergingPrefix() {
+    	RosettaPath p = RosettaPath.valueOf("a.b.c");
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.x")), is(false));
+    	assertThat(p.startsWith(RosettaPath.valueOf("x.b")), is(false));
+    }
+
+    @Test
+    void shouldTakeIndexIntoAccountWhenMatchingPrefix() {
+    	RosettaPath p = RosettaPath.valueOf("a.b(1).c");
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b(1)")), is(true));
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b(2)")), is(false));
+    }
+
+    @Test
+    void shouldTreatZeroIndexAsEquivalentToNoIndexWhenMatchingPrefix() {
+    	assertThat(RosettaPath.valueOf("a.b(0).c").startsWith(RosettaPath.valueOf("a.b")), is(true));
+    	assertThat(RosettaPath.valueOf("a.b.c").startsWith(RosettaPath.valueOf("a.b(0)")), is(true));
+    }
+
+    @Test
+    void shouldReportDepth() {
+    	assertThat(RosettaPath.valueOf("a").depth(), is(1));
+    	assertThat(RosettaPath.valueOf("a.b.c").depth(), is(3));
+    	// depth must stay in step with allElements(), which startsWith relies on
+    	assertThat(RosettaPath.valueOf("a.b.c.d").depth(), is(RosettaPath.valueOf("a.b.c.d").allElements().size()));
+    }
+
+    @Test
     void shouldMatchEquivalentPaths() {
     	RosettaPath path1 = RosettaPath.valueOf("root.a.b.c")
         		.newSubPath(Element.create("d", OptionalInt.of(0), of())) // index of 0 is equivalent to empty index


### PR DESCRIPTION
## Why

Flattening samples into grid cells is a hot path for the execution dashboard. In production it was burning ~92% of a core on each of four worker threads and allocating ~2.3 GB every ~200 ms, driving a young GC roughly five times a second. Thread dumps put the time under `ModelObjectFlattener.removeAllMetaPaths` → `RosettaPath.startsWith` → `RosettaPath.allElements` → `LinkedList`.

## What was slow

**`RosettaPath.startsWith`** materialised *both* paths with `allElements()`, which recursively allocates a `LinkedList` at every level, then compared them with `LinkedList.get(i)` — an O(n) indexed access, making each comparison O(depth²) and allocating ~2×depth list nodes.

**`ModelObjectFlattener.removeAllMetaPaths`** tested every flattened value path against every recorded meta path — O(values × metaPaths) `startsWith` calls per sample.

## What changed

`RosettaPath` now caches its `depth` at construction (it is immutable) and `startsWith` aligns the two paths by depth and walks the parent chains, allocating nothing.

`removeAllMetaPaths` exploits the fact that a meta path is always a *prefix* of the value paths it applies to: instead of scanning all meta paths per value, it walks each value path's ancestors and looks them up in a set. That is O(depth) per value path, independent of how many meta paths exist.

## Measurements

Isolated hot loop (4000 value paths × 250 meta paths, depth 12 — 1M `startsWith` calls per flatten):

| | ms per flatten | MB allocated per flatten |
|---|---|---|
| before | 307.8 | 3716 |
| `startsWith` fix only | 44.6 | 191 |
| both fixes | **2.2** | **1.3** |

End to end over 12 real CDM `TradeState` samples, run through the pruning + flattening pipeline as rosetta-products drives it:

| | ms per sample | MB per sample |
|---|---|---|
| before | 1.492 | 8.506 |
| after | 0.464 | 0.383 |

Note the fix removes allocation *churn*, not live set — post-GC heap is expected to be unchanged; the signal is GC frequency.

## Second change: honour thread interruption

Flattening is uninterruptible CPU work. A caller that bounds it with a timeout and then calls `Future.cancel(true)` had no way to stop it — the interrupt flag was never polled anywhere on the path, so the work ran to completion regardless and the thread stayed busy long after its result had been discarded. In rosetta-products this leaked one core-pegged thread per timed-out sample.

Both phases now poll the flag: the traversal, in the processor invoked per node, and the meta path removal, per flattened value. Polling is batched to one check per 1024 nodes, so it costs nothing measurable — re-measured on a 2100-cell object after adding it: allocation unchanged, no slowdown — while still checking the very first node so an already-cancelled call returns promptly.

`CancellationException` is used because `flatten()` cannot declare a checked exception, and the interrupt flag is deliberately left set for the caller. **This is a behaviour change** for any caller that invokes `flatten()` with the flag already set and expects it to complete; it is documented on the method.

## Correctness

Behaviour is unchanged; this is purely a rewrite of how the same result is computed.

- `RosettaPathTest` had **no** coverage of `startsWith` at all, so this adds it: prefix matching, divergence, longer-than-self, index sensitivity, and the existing rule that a zero index is equivalent to no index. Also asserts `depth()` stays in step with `allElements().size()`, which `startsWith` relies on.
- `ModelObjectFlattenerTest` gains a case with metadata nested several levels deep.
- Full `rune-runtime` + `rune-integration-tests` suites pass locally (1490 tests, 0 failures).
- While developing, both algorithms were run side by side over the same inputs and asserted to produce identical output.

## Context

Prepared by **eagle**, a SimonAgent agent, for STORY-1843. A companion PR ([rosetta-products#6963](https://github.com/REGnosys/rosetta-products/pull/6963)) removes redundant deep copies in `LabelBasedSampleRowCreator`; the two compound and are best measured together.

Slack thread: https://regnosys.slack.com/archives/C6PDTCEBU/p1785343892875199
