### PR TITLE
Dispatch CVE scanning via the shared GitHub App, skip on the fork

### DIFF
--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -13,12 +13,17 @@ on:
     # 02:00) to avoid all three hitting the NVD API / shared runners at once.
     - cron: '0 1 * * *'
 
-# The single step below doesn't use the default GITHUB_TOKEN, so it's
-# granted no permissions at all.
+# Neither step below uses the default GITHUB_TOKEN, so it's granted no
+# permissions at all.
 permissions: {}
 
 jobs:
   dispatch:
+    # `schedule` fires independently on every repo that has this file on its
+    # default branch - including REGnosys/rune-dsl, a fork of this repo.
+    # The CVE Scan Dispatcher App is only installed on finos/rune-dsl, so
+    # skip here rather than failing daily on the fork.
+    if: github.repository == 'finos/rune-dsl'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -27,13 +32,17 @@ jobs:
     steps:
       # The default GITHUB_TOKEN can't trigger another workflow run (GitHub's
       # anti-recursion guard silently no-ops workflow_dispatch calls made with
-      # it). This repo is a fork of a FINOS repo, and GitHub App installation
-      # requires org-owner rights we don't have on FINOS, so a fine-grained
-      # PAT (Actions: read/write on this repo only) is stored as a repository
-      # secret here instead of using the shared CVE Scan Dispatcher App.
+      # it), so this mints a short-lived token from the shared REGnosys CVE
+      # Scan Dispatcher GitHub App instead.
+      - name: Generate dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CVE_SCAN_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CVE_SCAN_DISPATCH_APP_PRIVATE_KEY }}
       - name: Trigger CVE scanning on ${{ matrix.ref }}
         env:
-          GH_TOKEN: ${{ secrets.CVE_SCAN_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run cve-scanning.yml \
             --ref ${{ matrix.ref }} \


### PR DESCRIPTION
## Summary
- Switches the CVE Scanning Schedule dispatcher to mint a token from the shared CVE Scan Dispatcher GitHub App (`actions/create-github-app-token`), same pattern as [rosetta-components](https://github.com/REGnosys/rosetta-components/blob/main/.github/workflows/cve-scanning-schedule.yml) and [finos/rune-common#697](https://github.com/finos/rune-common/pull/697), now that the App is installed and its secrets are configured on this repo.
- Adds a job-level guard (`if: github.repository == 'finos/rune-dsl'`) so the dispatch job is skipped on REGnosys/rune-dsl (a fork carrying this same file) instead of failing there daily - `schedule` triggers fire independently per-repo based on whatever's on that repo's own default branch, and the App/token aren't available on the fork.
- Removes the fine-grained PAT (`CVE_SCAN_DISPATCH_TOKEN`) dependency, which was scoped only to the fork.

## Test plan
- [ ] Confirm `CVE_SCAN_DISPATCH_APP_ID` / `CVE_SCAN_DISPATCH_APP_PRIVATE_KEY` secrets are present on this repo
- [ ] Manually trigger "CVE Scanning Schedule" via `workflow_dispatch` and confirm it dispatches `cve-scanning.yml` successfully on both `main` and `9.x.x`
- [ ] Confirm the equivalent run on REGnosys/rune-dsl (the fork) shows the job as skipped once this change syncs down, rather than failing