### PR TITLE
Backport to 9.x.x: optimise sample flattening to reduce CPU and memory use

### DIFF
--- a/rune-integration-tests/src/test/java/com/rosetta/model/lib/flatten/ModelObjectFlattenerTest.java
+++ b/rune-integration-tests/src/test/java/com/rosetta/model/lib/flatten/ModelObjectFlattenerTest.java
@@ -15,6 +15,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.stream.Collectors;
 
 @ExtendWith(InjectionExtension.class)
@@ -117,6 +118,75 @@ class ModelObjectFlattenerTest {
 				bar(1).b3(0): VALUE19
 				bar(1).b3(1): VALUE20
 				""");
+	}
+
+	@Test
+	void flattenTestWithMetadataNestedSeveralLevelsDeep() throws IOException {
+		JavaTestModel model = modelService.toJavaTestModel("""
+				namespace test
+
+				type Root:
+				    outer Outer (0..*)
+
+				type Outer:
+				    inner Inner (0..*)
+
+				type Inner:
+				    [metadata key]
+				    val string (0..*)
+				        [metadata scheme]
+				""").compile();
+
+		RosettaModelObject instance = model.evaluateExpression(RosettaModelObject.class, """
+				Root {
+		            outer: [
+		                Outer {
+		                    inner: [
+		                        Inner { val: ["A", "B"] },
+		                        Inner { val: ["C"] }
+		                    ]
+		                },
+		                Outer {
+		                    inner: [
+		                        Inner { val: ["D"] }
+		                    ]
+		                }
+		            ]
+		        }
+				""");
+
+		assertFlattenedValues(instance, """
+				outer(0).inner(0).val(0): A
+				outer(0).inner(0).val(1): B
+				outer(0).inner(1).val(0): C
+				outer(1).inner(0).val(0): D
+				""");
+	}
+
+	@Test
+	void flattenAbandonsWorkWhenTheCallingThreadIsInterrupted() throws IOException {
+		JavaTestModel model = modelService.toJavaTestModel("""
+				namespace test
+
+				type Root:
+				    a string (0..1)
+				""").compile();
+		RosettaModelObject instance = model.evaluateExpression(RosettaModelObject.class, """
+				Root { a: "VALUE" }
+				""");
+
+		// sanity check: it flattens normally when not interrupted
+		Assertions.assertEquals(1, modelObjectFlattener.flatten(instance).size());
+
+		try {
+			Thread.currentThread().interrupt();
+			Assertions.assertThrows(CancellationException.class, () -> modelObjectFlattener.flatten(instance));
+			Assertions.assertTrue(Thread.currentThread().isInterrupted(),
+				"the interrupt flag must be left set for the caller to act on");
+		} finally {
+			// clear the flag so it cannot leak into other tests on this thread
+			Thread.interrupted();
+		}
 	}
 
 	@Test

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/flatten/ModelObjectFlattener.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/flatten/ModelObjectFlattener.java
@@ -9,7 +9,7 @@ import com.rosetta.model.lib.process.AttributeMeta;
 import com.rosetta.model.lib.process.BuilderProcessor;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.concurrent.CancellationException;
 
 /**
  * Flattens a {@link RosettaModelObject} into a list of {@link RosettaPathValue} objects.
@@ -19,10 +19,22 @@ import java.util.stream.Collectors;
 public class ModelObjectFlattener {
 
     /**
+     * How many visited nodes to cover per interrupt check. Flattening is uninterruptible CPU work,
+     * so callers that bound it with a timeout need it to observe interruption; polling in batches
+     * keeps the cost of that immeasurably small relative to the work done per node.
+     */
+    private static final int INTERRUPT_CHECK_MASK = 1023;
+
+    /**
      * Flattens the provided RosettaModelObject.
+     * <p>
+     * Large objects can take a long time to flatten, so this honours interruption of the calling
+     * thread: if the thread's interrupt flag is set, flattening abandons its work and throws
+     * {@link CancellationException}. The interrupt flag is left set for the caller to act on.
      *
      * @param modelObject The RosettaModelObject to flatten.
      * @return A list of RosettaPathValue objects representing the flattened object.
+     * @throws CancellationException if the calling thread is interrupted while flattening.
      */
     public List<RosettaPathValue> flatten(RosettaModelObject modelObject) {
         FlattenerBuilderProcessor processor = new FlattenerBuilderProcessor();
@@ -35,6 +47,18 @@ public class ModelObjectFlattener {
     }
 
     /**
+     * Aborts if the calling thread has been interrupted, checking only once every
+     * {@link #INTERRUPT_CHECK_MASK}+1 calls.
+     *
+     * @param visitCount a monotonically increasing count of nodes visited so far.
+     */
+    private static void abortIfInterrupted(int visitCount) {
+        if ((visitCount & INTERRUPT_CHECK_MASK) == 0 && Thread.currentThread().isInterrupted()) {
+            throw new CancellationException("Interrupted while flattening a model object");
+        }
+    }
+
+    /**
      * Removes all metadata paths from the provided list of RosettaPathValues.
      *
      * @param metaPaths      The list of metadata paths to remove.
@@ -42,31 +66,53 @@ public class ModelObjectFlattener {
      * @return A new list of RosettaPathValues with metadata paths removed.
      */
     private List<RosettaPathValue> removeAllMetaPaths(List<RosettaPath> metaPaths, List<RosettaPathValue> pathValues) {
-        return pathValues.stream()
-                .map(pathValue -> new RosettaPathValue(removeAllMetaPaths(metaPaths, pathValue.getPath()), pathValue.getValue()))
-                .collect(Collectors.toList());
+        // A meta path is always a prefix of the value paths it applies to, so testing every value
+        // path against every meta path is unnecessary: looking each ancestor up in a set is O(depth)
+        // rather than O(metaPaths). This is the dominant cost when flattening large samples.
+        Set<RosettaPath> metaPathSet = new HashSet<>(metaPaths);
+        List<RosettaPathValue> result = new ArrayList<>(pathValues.size());
+        int visited = 0;
+        for (RosettaPathValue pathValue : pathValues) {
+            abortIfInterrupted(visited++);
+            result.add(new RosettaPathValue(removeAllMetaPaths(metaPathSet, pathValue.getPath()), pathValue.getValue()));
+        }
+        return result;
     }
 
     /**
      * Removes all metadata path segments from the provided RosettaPath.
      *
-     * @param metaPaths The list of metadata paths to use for filtering.
+     * @param metaPaths The metadata paths to use for filtering.
      * @param path      The RosettaPath to filter.
-     * @return A new RosettaPath with metadata segments removed.
+     * @return A new RosettaPath with metadata segments removed, and its first element trimmed.
      */
-    private RosettaPath removeAllMetaPaths(List<RosettaPath> metaPaths, RosettaPath path) {
-        LinkedList<RosettaPath.Element> elements = path.allElements();
-        metaPaths.stream()
-                .filter(path::startsWith)
-                .map(RosettaPath::allElements)
-                .map(LinkedList::size)
-                .map(i -> i - 1)
-                .distinct()
-                .sorted(Comparator.reverseOrder())
-                .forEach(i -> elements.remove((int) i));
+    private RosettaPath removeAllMetaPaths(Set<RosettaPath> metaPaths, RosettaPath path) {
+        int depth = path.depth();
+        RosettaPath.Element[] elements = new RosettaPath.Element[depth];
+        boolean[] isMetaSegment = new boolean[depth];
 
-        RosettaPath newPath = RosettaPath.createPathFromElements(elements);
-        return newPath.trimFirst();
+        int i = depth - 1;
+        for (RosettaPath ancestor = path; ancestor != null; ancestor = ancestor.getParent(), i--) {
+            elements[i] = ancestor.getElement();
+            // an ancestor that is itself a meta path contributes the segment naming the metadata field
+            isMetaSegment[i] = metaPaths.contains(ancestor);
+        }
+
+        RosettaPath result = null;
+        boolean firstRemainingTrimmed = false;
+        for (int j = 0; j < depth; j++) {
+            if (isMetaSegment[j]) {
+                continue;
+            }
+            if (!firstRemainingTrimmed) {
+                firstRemainingTrimmed = true;
+                continue;
+            }
+            result = result == null
+                    ? RosettaPath.createPath(elements[j])
+                    : result.newSubPath(elements[j]);
+        }
+        return result;
     }
 
     /**
@@ -77,6 +123,7 @@ public class ModelObjectFlattener {
 
         private final List<RosettaPathValue> rosettaPathValues = new ArrayList<>();
         private final List<RosettaPath> metaPaths = new ArrayList<>();
+        private int visited;
 
         /**
          * Returns the list of identified metadata paths.
@@ -96,6 +143,7 @@ public class ModelObjectFlattener {
 
         @Override
         public <R extends RosettaModelObject> boolean processRosetta(RosettaPath path, Class<R> rosettaType, RosettaModelObjectBuilder builder, RosettaModelObjectBuilder parent, AttributeMeta... metas) {
+            abortIfInterrupted(visited++);
             if (builder != null && parent instanceof FieldWithMeta) {
                 metaPaths.add(path);
             }
@@ -113,6 +161,7 @@ public class ModelObjectFlattener {
 
         @Override
         public <T> void processBasic(RosettaPath path, Class<T> rosettaType, T instance, RosettaModelObjectBuilder parent, AttributeMeta... metas) {
+            abortIfInterrupted(visited++);
             if (instance != null) {
                 if (parent instanceof FieldWithMeta) {
                     rosettaPathValues.add(new RosettaPathValue(path.getParent(), instance));

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/path/RosettaPath.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/path/RosettaPath.java
@@ -43,7 +43,10 @@ public class RosettaPath implements Comparable<RosettaPath> {
 	
     private final RosettaPath parent;
     private final Element element;
-    
+    // number of elements from the root to this path (inclusive); cached so startsWith()
+    // can align two paths without repeatedly rebuilding LinkedLists via allElements()
+    private final int depth;
+
     //a Path that has 0 notional elements so when you create a subPath from it you get a path with 1 element
     public static class NullPath extends RosettaPath {
     	public NullPath() {
@@ -58,6 +61,7 @@ public class RosettaPath implements Comparable<RosettaPath> {
     private RosettaPath(RosettaPath parent, Element element) {
         this.parent = parent;
         this.element = element;
+        this.depth = (parent == null ? 0 : parent.depth) + 1;
     }
 
     public static RosettaPath createPath(RosettaPath parent, Element element) {
@@ -148,6 +152,13 @@ public class RosettaPath implements Comparable<RosettaPath> {
         return parent;
     }
 
+    /**
+     * @return the number of elements from the root to this path, inclusive.
+     */
+    public int depth() {
+        return depth;
+    }
+
     public Element getElement() {
         return element;
     }
@@ -173,20 +184,29 @@ public class RosettaPath implements Comparable<RosettaPath> {
     	return parent.containsPath(subPath);
     }
 
+    // Walks the parent chains directly instead of materialising allElements() LinkedLists,
+    // which showed up as the dominant CPU/allocation hotspot when flattening large samples
+    // (many startsWith checks against many meta paths) - see STORY-1843.
     public boolean startsWith(RosettaPath other) {
-        LinkedList<RosettaPath.Element> list = this.allElements();
-        LinkedList<RosettaPath.Element> prefix = other.allElements();
-        if (prefix == null || prefix.isEmpty()) {
+        if (other.depth == 0) {
             return true;
         }
-        if (list == null || list.size() < prefix.size()) {
+        if (this.depth < other.depth) {
             return false;
         }
 
-        for (int i = 0; i < prefix.size(); i++) {
-            if (!list.get(i).equals(prefix.get(i))) {
+        RosettaPath cursor = this;
+        for (int toSkip = this.depth - other.depth; toSkip > 0; toSkip--) {
+            cursor = cursor.parent;
+        }
+
+        RosettaPath otherCursor = other;
+        while (otherCursor != null) {
+            if (!Objects.equals(cursor.element, otherCursor.element)) {
                 return false;
             }
+            cursor = cursor.parent;
+            otherCursor = otherCursor.parent;
         }
 
         return true;

--- a/rune-runtime/src/test/java/com/rosetta/model/lib/path/RosettaPathTest.java
+++ b/rune-runtime/src/test/java/com/rosetta/model/lib/path/RosettaPathTest.java
@@ -255,6 +255,53 @@ public class RosettaPathTest {
     }
     
     @Test
+    void shouldStartWithItself() {
+    	RosettaPath p = RosettaPath.valueOf("a.b.c");
+    	assertThat(p.startsWith(p), is(true));
+    }
+
+    @Test
+    void shouldStartWithProperPrefix() {
+    	RosettaPath p = RosettaPath.valueOf("a.b.c.d");
+    	assertThat(p.startsWith(RosettaPath.valueOf("a")), is(true));
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b")), is(true));
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b.c")), is(true));
+    }
+
+    @Test
+    void shouldNotStartWithLongerPath() {
+    	assertThat(RosettaPath.valueOf("a.b").startsWith(RosettaPath.valueOf("a.b.c")), is(false));
+    }
+
+    @Test
+    void shouldNotStartWithDivergingPrefix() {
+    	RosettaPath p = RosettaPath.valueOf("a.b.c");
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.x")), is(false));
+    	assertThat(p.startsWith(RosettaPath.valueOf("x.b")), is(false));
+    }
+
+    @Test
+    void shouldTakeIndexIntoAccountWhenMatchingPrefix() {
+    	RosettaPath p = RosettaPath.valueOf("a.b(1).c");
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b(1)")), is(true));
+    	assertThat(p.startsWith(RosettaPath.valueOf("a.b(2)")), is(false));
+    }
+
+    @Test
+    void shouldTreatZeroIndexAsEquivalentToNoIndexWhenMatchingPrefix() {
+    	assertThat(RosettaPath.valueOf("a.b(0).c").startsWith(RosettaPath.valueOf("a.b")), is(true));
+    	assertThat(RosettaPath.valueOf("a.b.c").startsWith(RosettaPath.valueOf("a.b(0)")), is(true));
+    }
+
+    @Test
+    void shouldReportDepth() {
+    	assertThat(RosettaPath.valueOf("a").depth(), is(1));
+    	assertThat(RosettaPath.valueOf("a.b.c").depth(), is(3));
+    	// depth must stay in step with allElements(), which startsWith relies on
+    	assertThat(RosettaPath.valueOf("a.b.c.d").depth(), is(RosettaPath.valueOf("a.b.c.d").allElements().size()));
+    }
+
+    @Test
     void shouldMatchEquivalentPaths() {
     	RosettaPath path1 = RosettaPath.valueOf("root.a.b.c")
         		.newSubPath(Element.create("d", OptionalInt.of(0), of())) // index of 0 is equivalent to empty index


### PR DESCRIPTION
Backport of #1348 to `9.x.x`.

Cherry-pick of `b2be24aa` — applied cleanly, no conflicts and no adaptation needed. `#1348` is the only commit touching `RosettaPath` or `ModelObjectFlattener` between `9.x.x` and `main`, so this brings the two branches to parity for these files.

## What it does

**`RosettaPath.startsWith`** materialised both paths into `LinkedList`s via the recursive `allElements()`, then compared them with `LinkedList.get(i)` — an O(n) indexed access, so O(depth²) per call with an allocation at every level. It now caches each path's depth at construction and walks the parent chains directly, allocating nothing.

**`ModelObjectFlattener.removeAllMetaPaths`** tested every flattened value path against every recorded meta path — O(values × metaPaths). A meta path is always a *prefix* of the paths it applies to, so each value path's ancestors are now looked up in a set instead: O(depth) per value path, independent of how many meta paths exist.

**Interruption** is now honoured. Flattening is uninterruptible CPU work, so a caller that bounds it with a timeout and calls `Future.cancel(true)` previously had no way to stop it. Both phases poll the flag, batched to one check per 1024 nodes.

## Why backport

Production impact on the 10.x line was substantial — an isolated hot loop went from 307.8 ms and 3.7 GB allocated per flatten to 2.2 ms and 1.3 MB, and end-to-end over real CDM samples from 1.492 ms / 8.5 MB per sample to 0.184 ms / 0.32 MB. The same slow paths exist unchanged on `9.x.x`.

## Verification

`RosettaPathTest` 37/37 and `ModelObjectFlattenerTest` 4/4 pass on this branch, checkstyle clean. Behaviour is unchanged — the PR adds `startsWith` coverage, which the class previously had none of, plus a flattener case with metadata nested several levels deep and one asserting interruption is observed.

Prepared by **eagle**, a SimonAgent agent.

Slack thread: https://regnosys.slack.com/archives/C6PDTCEBU/p1785343892875199
