### PR TITLE
Apply the setup's Rune config wiring after the injector is built

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/StandaloneSetupConfigWiringTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/config/StandaloneSetupConfigWiringTest.java
@@ -1,0 +1,85 @@
+package com.regnosys.rosetta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.xtext.testing.GlobalRegistries;
+import org.eclipse.xtext.testing.GlobalRegistries.GlobalStateMemento;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.regnosys.rosetta.RosettaRuntimeModule;
+import com.regnosys.rosetta.RosettaStandaloneSetup;
+import com.regnosys.rosetta.utils.RuneConfigurationHolder;
+
+/**
+ * A setup's configured config file and classpath classloader must reach the configuration provider
+ * even when a subclass replaces {@link RosettaStandaloneSetup#createInjector()} to mix in its own
+ * runtime module — which is what the IDE/language-server setups here and every custom generator
+ * setup downstream do. When it did not, a model built through such a setup silently fell back to the
+ * default configuration and looked its dependencies' configs up through the thread context
+ * classloader, which in a Maven build is the plugin realm and cannot see the model's dependencies.
+ */
+public class StandaloneSetupConfigWiringTest {
+
+	private GlobalStateMemento stateBeforeSetup;
+
+	@BeforeEach
+	void rememberGlobalState() {
+		stateBeforeSetup = GlobalRegistries.makeCopyOfGlobalState();
+	}
+
+	@AfterEach
+	void restoreGlobalState() {
+		stateBeforeSetup.restoreGlobalState();
+	}
+
+	/** Mirrors {@code CDMRosettaSetup}/{@code RosettaIdeSetup}: a custom module, built in createInjector. */
+	private static final class CustomModuleSetup extends RosettaStandaloneSetup {
+		@Override
+		public Injector createInjector() {
+			return Guice.createInjector(new RosettaRuntimeModule() {
+			});
+		}
+	}
+
+	@Test
+	void configFileAndClasspathClassLoaderSurviveACustomCreateInjector(@TempDir Path tempDir) throws Exception {
+		// The model's own config, passed as an explicit file - this is what the Maven plugin does, since
+		// at generate-sources time the config is not on the classpath yet.
+		Path primaryConfig = tempDir.resolve("rune-config.yml");
+		Files.writeString(primaryConfig, "model:\n  name: Child Model\n");
+
+		// A dependency's config, only reachable through the project classloader the plugin passes in.
+		Path dependencyRoot = Files.createDirectory(tempDir.resolve("dependency-classes"));
+		Files.writeString(dependencyRoot.resolve("rune-config.yml"),
+				"model:\n  name: Parent Model\nnamespaceConfig:\n- id: parentSchema\n  namespace: parent.ns\n"
+						+ "  schemaConfig:\n    schema: parentSchema\n    configPath: xml-config/parent-config.json\n");
+
+		// Closed before the test ends so the @TempDir can be deleted on Windows
+		try (URLClassLoader dependencyClassLoader =
+				new URLClassLoader(new URL[] { dependencyRoot.toUri().toURL() }, null)) {
+			Injector injector = new CustomModuleSetup()
+					.setConfigFile(primaryConfig.toString())
+					.setClasspathClassLoader(dependencyClassLoader)
+					.createInjectorAndDoEMFRegistration();
+
+			RuneConfiguration config = injector.getInstance(RuneConfigurationHolder.class).get();
+
+			// The explicit config file was read, rather than falling back to the default configuration.
+			assertEquals("Child Model", config.getModel().getName());
+			// The dependency's schema config was discovered through the given classloader and unioned in,
+			// so a schema marked [externalConfig] in a parent model still resolves its config path.
+			assertEquals("xml-config/parent-config.json",
+					config.findSchemaConfig("parentSchema").orElseThrow().getConfigPath());
+		}
+	}
+}

--- a/rune-lang/src/main/java/com/regnosys/rosetta/RosettaStandaloneSetup.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/RosettaStandaloneSetup.java
@@ -4,10 +4,8 @@
  */
 package com.regnosys.rosetta;
 
-import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Module;
 import com.regnosys.rosetta.config.file.RuneConfigurationFileProvider;
 import com.regnosys.rosetta.rosetta.RosettaPackage;
 import com.regnosys.rosetta.rosetta.expression.ExpressionPackage;
@@ -27,6 +25,10 @@ public class RosettaStandaloneSetup extends RosettaStandaloneSetupGenerated {
         new RosettaStandaloneSetup().createInjectorAndDoEMFRegistration();
     }
 
+    /**
+     * Points the setup at an explicit configuration file, instead of discovering the project's own
+     * config on the classpath. Applied by {@link #createInjectorAndDoEMFRegistration()}.
+     */
     public RosettaStandaloneSetup setConfigFile(String configFile) {
         this.configFile = configFile;
         return this;
@@ -37,6 +39,7 @@ public class RosettaStandaloneSetup extends RosettaStandaloneSetupGenerated {
      * the classpath. In a Maven build the thread context classloader is the plugin realm, which does
      * not see the project's compile dependencies, so the plugin passes a classloader over the project
      * classpath here so that dependency {@code serializationConfig} entries are unioned in.
+     * Applied by {@link #createInjectorAndDoEMFRegistration()}.
      */
     public RosettaStandaloneSetup setClasspathClassLoader(ClassLoader classpathClassLoader) {
         this.classpathClassLoader = classpathClassLoader;
@@ -45,17 +48,7 @@ public class RosettaStandaloneSetup extends RosettaStandaloneSetupGenerated {
 
     @Override
     public Injector createInjector() {
-        return Guice.createInjector(new RosettaRuntimeModule(), binder -> {
-            if (configFile != null || classpathClassLoader != null) {
-                RuneConfigurationFileProvider fileProvider = configFile != null
-                        ? RuneConfigurationFileProvider.createFromFile(configFile)
-                        : new RuneConfigurationFileProvider();
-                if (classpathClassLoader != null) {
-                    fileProvider.setClassLoader(classpathClassLoader);
-                }
-                binder.bind(RuneConfigurationFileProvider.class).toInstance(fileProvider);
-            }
-        });
+        return Guice.createInjector(new RosettaRuntimeModule());
     }
 
 
@@ -71,6 +64,43 @@ public class RosettaStandaloneSetup extends RosettaStandaloneSetupGenerated {
         if (!EPackage.Registry.INSTANCE.containsKey(ExpressionPackage.eNS_URI)) {
             EPackage.Registry.INSTANCE.put(ExpressionPackage.eNS_URI, ExpressionPackage.eINSTANCE);
         }
-        return super.createInjectorAndDoEMFRegistration();
+        Injector injector = super.createInjectorAndDoEMFRegistration();
+        configureRuneConfigurationFileProvider(injector);
+        return injector;
+    }
+
+    /**
+     * Applies {@link #setConfigFile(String)}/{@link #setClasspathClassLoader(ClassLoader)} to the
+     * injector's {@link RuneConfigurationFileProvider}.
+     * <p>
+     * This deliberately happens <em>after</em> the injector has been built, rather than as an extra
+     * Guice module inside {@link #createInjector()}: virtually every subclass of this setup (the IDE
+     * and language-server setups here, and custom generator setups downstream) overrides
+     * {@code createInjector()} to mix in its own module, and any binding added there would be
+     * silently dropped by those subclasses. Dropping it means the model's own {@code rune-config.yml}
+     * is not read and, worse, dependency configs are looked up through the thread context
+     * classloader — which in a Maven build is the plugin realm and cannot see the project's model
+     * dependencies at all. Configuring the (singleton) provider afterwards works whatever the
+     * subclass does with {@code createInjector()}. The configuration is only read lazily on first
+     * use, so this is still in time.
+     */
+    private void configureRuneConfigurationFileProvider(Injector injector) {
+        if (configFile == null && classpathClassLoader == null) {
+            return;
+        }
+        RuneConfigurationFileProvider fileProvider = injector.getInstance(RuneConfigurationFileProvider.class);
+        if (fileProvider != injector.getInstance(RuneConfigurationFileProvider.class)) {
+            throw new IllegalStateException(RuneConfigurationFileProvider.class.getSimpleName()
+                    + " is not bound as a singleton in " + getClass().getName() + "'s injector, so the configured "
+                    + "config file and classpath classloader would not reach the instance that reads the "
+                    + "configuration. Remove the non-singleton binding of "
+                    + RuneConfigurationFileProvider.class.getName() + " from the runtime module.");
+        }
+        if (configFile != null) {
+            fileProvider.setConfigFile(configFile);
+        }
+        if (classpathClassLoader != null) {
+            fileProvider.setClassLoader(classpathClassLoader);
+        }
     }
 }

--- a/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationFileProvider.java
+++ b/rune-runtime/src/main/java/com/regnosys/rosetta/config/file/RuneConfigurationFileProvider.java
@@ -2,6 +2,7 @@ package com.regnosys.rosetta.config.file;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -17,6 +18,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Locates the Rune configuration file(s) to read.
+ * <p>
+ * Bound as a singleton so that whoever creates the injector can still point the provider at an
+ * explicit config file and/or a project classloader <em>after</em> the injector exists (see
+ * {@code RosettaStandaloneSetup#createInjectorAndDoEMFRegistration()}). The configuration itself is
+ * only read lazily, on first use, so post-creation configuration is picked up.
+ */
+@Singleton
 public class RuneConfigurationFileProvider implements Provider<URL> {
     public static final String FILE_NAME = "rune-config.yml";
     public static final String LEGACY_FILE_NAME = "rosetta-config.yml";
@@ -25,8 +35,8 @@ public class RuneConfigurationFileProvider implements Provider<URL> {
     private static final AtomicBoolean LEGACY_WARNING_LOGGED = new AtomicBoolean(false);
 
     // When null, the default name is resolved with a fallback to the legacy name.
-    private final String fileName;
-    private final boolean loadFromClasspath;
+    private String fileName;
+    private boolean loadFromClasspath;
     // The classloader used to discover configuration files on the classpath. When null, the thread
     // context classloader is used. In a Maven build the thread context classloader is the plugin
     // realm, which does not see the project's compile dependencies, so the plugin sets this to a
@@ -38,6 +48,16 @@ public class RuneConfigurationFileProvider implements Provider<URL> {
     }
     public static RuneConfigurationFileProvider createFromClasspath(String fileName) {
         return new RuneConfigurationFileProvider(true, fileName);
+    }
+
+    /**
+     * Points this provider at an explicit configuration file on disk, instead of discovering the
+     * primary config on the classpath. Dependency configs are still discovered from the classpath
+     * (see {@link #getResources()}).
+     */
+    public void setConfigFile(String configFile) {
+        this.loadFromClasspath = false;
+        this.fileName = configFile;
     }
 
     /** Sets the classloader used to discover configuration files on the classpath. */


### PR DESCRIPTION
## Problem

A model built through a custom Xtext setup silently loses its Rune configuration — both its **own** `rune-config.yml` and its **dependencies'** configs.

`RosettaStandaloneSetup` accepts a config file (`setConfigFile`) and a classloader over the project's compile classpath (`setClasspathClassLoader`), and `rune-maven-plugin` sets both. The classloader matters because in a Maven build the thread context classloader is the *plugin realm*, which cannot see the project's model dependencies at all.

Both were installed as an extra Guice module **inside `createInjector()`**. But virtually every subclass of the setup overrides `createInjector()` to mix in its own runtime module — `RosettaIdeSetup` and `RosettaServerSetup` here, `CDMRosettaSetup` (rosetta-code-generators) and `BspIdeSetup` (rosetta-components) downstream — and so silently dropped that binding:

```java
public final class CDMRosettaSetup extends RosettaStandaloneSetup {
    @Override
    public Injector createInjector() {
        return Guice.createInjector(new CDMRuntimeModule());   // base-class config wiring lost
    }
}
```

The provider then fell back to the plugin realm and found no config at all (`No configuration file was found. Falling back to the default configuration.`).

This became a build failure as soon as a parent model started declaring a schema marked `[externalConfig]`. `SchemaValidator` requires a matching `schemaConfig` entry, which lives in the *parent's* `rune-config.yml` and is only reachable through the project classloader. Concretely, bumping `rune-fpml` to 3.4.0 in [finos/common-domain-model#4988](https://github.com/finos/common-domain-model/pull/4988) broke CDM's `generate-json-schema-src` execution:

```
[INFO] --- rune:10.3.0:generate (generate-json-schema-src) @ cdm-java ---
[WARNING] No configuration file was found. Falling back to the default configuration.
[ERROR] ERROR:Schema 'fpml513Recordkeeping' is marked [externalConfig] but no external
        serialization configuration is configured for it (consolidated-desc.rosetta line 11)
[ERROR] ERROR:Schema 'fpml513Confirmation' is marked [externalConfig] but no external
        serialization configuration is configured for it (consolidated-desc.rosetta line 14)
```

It looked environment-specific because that execution lives in a Maven profile only CI activates — the default execution uses `RosettaStandaloneSetup` directly and worked. It reproduces anywhere with `mvn -pl rosetta-source -Pjson-schema generate-sources`.

## Changes

**`RuneConfigurationFileProvider`** — bound as a `@Singleton`, with `fileName`/`loadFromClasspath` made mutable and a `setConfigFile(String)` setter added next to the existing `setClassLoader`, so the provider can still be pointed at a config file after the injector exists.

**`RosettaStandaloneSetup`** — `createInjector()` goes back to plain `Guice.createInjector(new RosettaRuntimeModule())`; the configuration is applied from `createInjectorAndDoEMFRegistration()` instead, which no subclass overrides. The wiring therefore survives whatever a subclass does with `createInjector()`, and no downstream change is needed. The configuration is read lazily through `RuneConfigurationHolder`, so applying it after injector creation is still in time. A guard fails loudly if `RuneConfigurationFileProvider` is rebound out of singleton scope, where post-creation configuration could not take effect.

**`StandaloneSetupConfigWiringTest`** (new) — a setup subclass that replaces `createInjector()` must still read the explicit config file and union in a dependency config reachable only through the given classloader. Fails on `main` (it picks up an unrelated config from the test classpath — the same silent-wrong-config failure mode), passes here.

## Verification

- New regression test passes; reverting only `RosettaStandaloneSetup` makes it fail.
- End-to-end: this branch installed as a snapshot, then the exact failing CDM build re-run against the **released** `default-cdm-generators` 12.6.1 → `BUILD SUCCESS`, no `[externalConfig]` errors, no fallback warning, `consolidated-desc.rosetta` validated and generated.
- Full `mvn clean install`: green, 1492 integration tests + all other modules, 0 failures.
