### PR TITLE
Note in CLAUDE.md that PRs are raised from a fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,4 @@ The codebase is mid-migration from Xtend to plain Java (~64 `.xtend` files remai
 
 - IntelliJ has limited Xtext support: it can't edit `.xtend`/`.xtext` or run `GenerateRosetta.mwe2` — let Maven handle those and edit/run regular Java there. Eclipse "IDE for Java and DSL Developers" (2025-06) is the supported full IDE. See `README.md` for IDE setup and troubleshooting.
 - This is a FINOS project; contributions require a CLA and go through PRs (see `CONTRIBUTING.md`).
+- Raise pull requests from a fork: push the branch to your own fork and open the PR against `finos/rune-dsl`, never pushing a branch to this repository. `CONTRIBUTING.md` requires this of everyone, maintainers included — write access does not exempt you, and a PR whose head is this repository has to be closed and re-raised.


### PR DESCRIPTION
`CONTRIBUTING.md` already states this, for everyone:

> 4. Fork the project repository and prepare your proposed contribution.
> …
> * All contributions MUST be submitted as pull requests, including contributions by Maintainers.

`CLAUDE.md` is what an agent reads while working in this repository, and it did not repeat the rule. A maintainer's agent has write access here, so pushing a branch straight to `finos/rune-dsl` succeeds — the PR then has this repository as its head and has to be closed and re-raised from a fork. That happened on #1354, re-raised as #1355.

This adds one line to the existing `## Notes` list, next to the CLA note, pointing at `CONTRIBUTING.md` as the source of the rule.
